### PR TITLE
chore(Routes): Added Service pay to switch

### DIFF
--- a/src/StockportWebapp/Utils/TypeRoutes.cs
+++ b/src/StockportWebapp/Utils/TypeRoutes.cs
@@ -21,6 +21,7 @@
                     return $"/groups/{slug}";
                 case "payment":
                     return $"/payment/{slug}";
+                case "servicePayPayment":
                 case "service-pay-payment":
                     return $"/service-pay-payment/{slug}";
                 case "showcase":


### PR DESCRIPTION
Includes:

- Added case servicePayPayment within routes switch. There currently is a case for "service-pay-payment", this is not the type which is returned from the contentapi but am not sure if it maybe somewhere so have kept the original and added the correct type name to the switch to allow the route to be generated.