### PR TITLE
fix(response_caching): add attribute 'Location'

### DIFF
--- a/src/StockportWebapp/Controllers/EventsController.cs
+++ b/src/StockportWebapp/Controllers/EventsController.cs
@@ -240,7 +240,7 @@ namespace StockportWebapp.Controllers
         }
 
         [Route("/events/add-your-event")]
-        [ResponseCache(NoStore = true, Duration = 0)]
+        [ResponseCache(Location = ResponseCacheLocation.None, Duration = 0, NoStore = true)]
         public IActionResult AddYourEvent()
         {
             var eventSubmission = new EventSubmission();
@@ -250,7 +250,7 @@ namespace StockportWebapp.Controllers
         [HttpPost]
         [Route("/events/add-your-event")]
         [ServiceFilter(typeof(ValidateReCaptchaAttribute))]
-        [ResponseCache(NoStore = true, Duration = 0)]
+        [ResponseCache(Location = ResponseCacheLocation.None, Duration = 0, NoStore = true)]
         public async Task<IActionResult> AddYourEvent(EventSubmission eventSubmission)
         {
             if (!ModelState.IsValid)

--- a/src/StockportWebapp/Controllers/GroupsController.cs
+++ b/src/StockportWebapp/Controllers/GroupsController.cs
@@ -77,7 +77,7 @@ namespace StockportWebapp.Controllers
             _featureToggles = featureToggles;
         }
 
-        [ResponseCache(NoStore = true, Duration = 0)]
+        [ResponseCache(Location = ResponseCacheLocation.None, Duration = 0, NoStore = true)]
         [Route("/groups")]
         public async Task<IActionResult> Index()
         {
@@ -121,7 +121,7 @@ namespace StockportWebapp.Controllers
             return View(model);
         }
 
-        [ResponseCache(NoStore = true, Duration = 0)]
+        [ResponseCache(Location = ResponseCacheLocation.None, Duration = 0, NoStore = true)]
         [Route("/groups/{slug}")]
         public async Task<IActionResult> Detail(string slug, bool confirmedUpToDate = false)
         {
@@ -183,7 +183,7 @@ namespace StockportWebapp.Controllers
             return group.GroupAdministrators.Items.Any(_ => _.Email == email);
         }
 
-        [ResponseCache(NoStore = true, Duration = 0)]
+        [ResponseCache(Location = ResponseCacheLocation.None, Duration = 0, NoStore = true)]
         [Route("groups/results")]
         public async Task<IActionResult> Results([FromQuery] int page, [FromQuery] int pageSize, GroupSearch groupSearch)
         {
@@ -311,7 +311,7 @@ namespace StockportWebapp.Controllers
 
         [HttpGet]
         [Route("/groups/{slug}/change-group-info")]
-        [ResponseCache(NoStore = true, Duration = 0)]
+        [ResponseCache(Location = ResponseCacheLocation.None, Duration = 0, NoStore = true)]
         public ActionResult ChangeGroupInfo(string slug, string groupname)
         {
             var model = new ChangeGroupInfoViewModel
@@ -326,7 +326,7 @@ namespace StockportWebapp.Controllers
         [HttpPost]
         [Route("/groups/{slug}/change-group-info")]
         [ServiceFilter(typeof(ValidateReCaptchaAttribute))]
-        [ResponseCache(NoStore = true, Duration = 0)]
+        [ResponseCache(Location = ResponseCacheLocation.None, Duration = 0, NoStore = true)]
         public IActionResult ChangeGroupInfo(string slug, ChangeGroupInfoViewModel submission)
         {
             if (!ModelState.IsValid)
@@ -346,7 +346,7 @@ namespace StockportWebapp.Controllers
 
         [HttpGet]
         [Route("/groups/{slug}/report-group-info")]
-        [ResponseCache(NoStore = true, Duration = 0)]
+        [ResponseCache(Location = ResponseCacheLocation.None, Duration = 0, NoStore = true)]
         public ActionResult ReportGroupInfo(string slug, string groupname)
         {
             var model = new ReportGroupViewModel
@@ -361,7 +361,7 @@ namespace StockportWebapp.Controllers
         [HttpPost]
         [Route("/groups/{slug}/report-group-info")]
         [ServiceFilter(typeof(ValidateReCaptchaAttribute))]
-        [ResponseCache(NoStore = true, Duration = 0)]
+        [ResponseCache(Location = ResponseCacheLocation.None, Duration = 0, NoStore = true)]
         public IActionResult ReportGroupInfo(string slug, ReportGroupViewModel submission)
         {
             if (!ModelState.IsValid)
@@ -682,9 +682,9 @@ namespace StockportWebapp.Controllers
             return View();
         }
 
-        [ResponseCache(NoStore = true, Duration = 0)]
         [Route("/groups/manage")]
         [ServiceFilter(typeof(GroupAuthorisation))]
+        [ResponseCache(Location = ResponseCacheLocation.None, Duration = 0, NoStore = true)]
         public async Task<IActionResult> Manage(LoggedInPerson loggedInPerson)
         {
             var response = await _repository.GetAdministratorsGroups(loggedInPerson.Email);
@@ -985,10 +985,10 @@ namespace StockportWebapp.Controllers
             return View();
         }
 
-        [ResponseCache(NoStore = true, Duration = 0)]
         [HttpGet]
         [Route("/groups/manage/{slug}/update")]
         [ServiceFilter(typeof(GroupAuthorisation))]
+        [ResponseCache(Location = ResponseCacheLocation.None, Duration = 0, NoStore = true)]
         public async Task<IActionResult> EditGroup(string slug, LoggedInPerson loggedInPerson)
         {
             var response = await _repository.Get<Group>(slug, _managementQuery);
@@ -1181,9 +1181,9 @@ namespace StockportWebapp.Controllers
             return await _repository.Get<GroupResults>(queries: queries);
         }
 
-        [ResponseCache(NoStore = true, Duration = 0)]
         [HttpGet]
         [Route("/groups/favourites/get-count")]
+        [ResponseCache(Location = ResponseCacheLocation.None, Duration = 0, NoStore = true)]
         public async Task<int> GetCount()
         {
             var queries = new List<Query>();
@@ -1205,9 +1205,9 @@ namespace StockportWebapp.Controllers
             return groupResults.Groups.ToList().Count(a => a.Status != "Archived");
         }
 
-        [ResponseCache(NoStore = true, Duration = 0)]
         [HttpGet]
         [Route("/groups/favourites")]
+        [ResponseCache(Location = ResponseCacheLocation.None, Duration = 0, NoStore = true)]
         public async Task<IActionResult> FavouriteGroups([FromQuery] int page, [FromQuery] int pageSize)
         {
             var response = await GetFavouriteGroupResults();


### PR DESCRIPTION
Added "Location" property to ResponseCache attribute on some actions within two controllers, which will also set the pragma headers no-cache.

[Jira : Card 6585](https://stockportbi.atlassian.net/browse/DIGITAL-6585)

The reason was in Kibana there was about 5000 logs for this warning over a month, to do with some actions in the Events and Groups controller. According to the [docs](https://docs.microsoft.com/en-us/aspnet/core/performance/caching/response?view=aspnetcore-5.0#responsecache-attribute) the pragma header will also be set if the Location property is included.

To test : pull the branch and build, make sure no issues... with the endpoints effected.