### PR TITLE
6572 - Tab orders fix

### DIFF
--- a/src/StockportWebapp/Models/EventHomepage.cs
+++ b/src/StockportWebapp/Models/EventHomepage.cs
@@ -6,7 +6,6 @@ namespace StockportWebapp.Models
     {
         public List<EventHomepageRow> Rows { get; set; }
         public List<EventCategory> Categories { get; set; }
-
         public string MetaDescription { get; set; }
 
         public EventHomepage()
@@ -24,9 +23,9 @@ namespace StockportWebapp.Models
                 {
                     result.Items.Add(new GenericFeaturedItem { Icon = cat.Icon, Title = cat.Name, Url = $"/events?category={cat.Slug}" });
                 }
-
+                
                 result.ButtonText = "View more categories";
-
+                result.HideButton = true;
                 return result;
             }
         }

--- a/src/StockportWebapp/Models/EventHomepage.cs
+++ b/src/StockportWebapp/Models/EventHomepage.cs
@@ -23,8 +23,8 @@ namespace StockportWebapp.Models
                 {
                     result.Items.Add(new GenericFeaturedItem { Icon = cat.Icon, Title = cat.Name, Url = $"/events?category={cat.Slug}" });
                 }
-                
-                result.ButtonText = "View more categories";
+
+                result.ButtonText = string.Empty;
                 result.HideButton = true;
                 return result;
             }

--- a/src/StockportWebapp/Models/GenericFeaturedItemList.cs
+++ b/src/StockportWebapp/Models/GenericFeaturedItemList.cs
@@ -7,5 +7,6 @@ namespace StockportWebapp.Models
         public List<GenericFeaturedItem> Items { get; set; }
         public string ButtonText { get; set; }
         public string ButtonCssClass { get; set; }
+        public bool HideButton { get; set; }
     }
 }

--- a/src/StockportWebapp/ProcessedModels/ProcessedGroupHomepage.cs
+++ b/src/StockportWebapp/ProcessedModels/ProcessedGroupHomepage.cs
@@ -34,7 +34,7 @@ namespace StockportWebapp.ProcessedModels
                 }
 
                 result.ButtonText = "View more categories";
-
+                result.HideButton = true;
                 return result;
             }
         }

--- a/src/StockportWebapp/ProcessedModels/ProcessedGroupHomepage.cs
+++ b/src/StockportWebapp/ProcessedModels/ProcessedGroupHomepage.cs
@@ -33,7 +33,7 @@ namespace StockportWebapp.ProcessedModels
                     result.Items.Add(new GenericFeaturedItem { Icon = cat.Icon, Title = cat.Name, Url = $"/groups/results?category={cat.Slug}&order=Name+A-Z" });
                 }
 
-                result.ButtonText = "View more categories";
+                result.ButtonText = string.Empty;
                 result.HideButton = true;
                 return result;
             }

--- a/src/StockportWebapp/ProcessedModels/ProcessedGroupHomepage.cs
+++ b/src/StockportWebapp/ProcessedModels/ProcessedGroupHomepage.cs
@@ -33,8 +33,7 @@ namespace StockportWebapp.ProcessedModels
                     result.Items.Add(new GenericFeaturedItem { Icon = cat.Icon, Title = cat.Name, Url = $"/groups/results?category={cat.Slug}&order=Name+A-Z" });
                 }
 
-                result.ButtonText = string.Empty;
-                result.HideButton = true;
+                result.ButtonText = "View more categories";
                 return result;
             }
         }

--- a/src/StockportWebapp/ViewModels/GroupStartPage.cs
+++ b/src/StockportWebapp/ViewModels/GroupStartPage.cs
@@ -33,7 +33,8 @@ namespace StockportWebapp.ViewModels
                     result.Items.Add(new GenericFeaturedItem { Icon = cat.Icon, Title = cat.Name, Url = $"/groups/results?category={cat.Slug}&order=Name+A-Z" });
                 }
 
-                result.ButtonText = "View more categories";
+                result.ButtonText = string.Empty;
+                result.HideButton = true;
 
                 return result;
             }

--- a/src/StockportWebapp/Views/stockportgov/Shared/GenericFeaturedItemList.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/GenericFeaturedItemList.cshtml
@@ -8,30 +8,43 @@
     @for (var count = 0; count < noOfInitialTopics; count += 4)
     {
         <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
-            <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)'/>
-        </div>
-    }
-    
-</div>
-@if (!string.IsNullOrEmpty(Model.ButtonText))
-{
-    <div class="generic-list-see-more-container">
-        @for (var count = 8; count < Model.Items.Count(); count += 4)
-        {
-            <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
-                <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)' />
-            </div>
-        }
-    </div>
-    if (Model.Items.Count > 9)
-    {
-        <div>
-            <div class="featured-content-button-wrapper">
-                <stock-button id="see-more-services" class="@Model.ButtonCssClass generic-list-see-more button-up-down">@Model.ButtonText</stock-button>
-            </div>
+            <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)' />
         </div>
     }
 
+</div>
+@if (!string.IsNullOrEmpty(Model.ButtonText))
+{
+    @if (Model.HideButton == true)
+    {
+        @foreach (var item in Model.Items)
+        {
+            <div class="generic-list-see-more-container">
+                <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
+                    <partial name="GenericFeaturedItem" model='item' />
+                </div>
+            </div>
+        }
+    }
+    else
+    {
+        @for (var count = 8; count < Model.Items.Count(); count += 4)
+        {
+            <div class="generic-list-see-more-container">
+                <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
+                    <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)' />
+                </div>
+            </div>
+        }
+        if (Model.Items.Count > 9)
+        {
+            <div>
+                <div class="featured-content-button-wrapper">
+                    <stock-button id="see-more-services" class="@Model.ButtonCssClass generic-list-see-more button-up-down">@Model.ButtonText</stock-button>
+                </div>
+            </div>
+        }
+    }
 }
 
 <script type="text/javascript" src="assets/javascript/stockportgov/EventFeatureItemFocus.js"></script>

--- a/src/StockportWebapp/Views/stockportgov/Shared/GenericFeaturedItemList.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/GenericFeaturedItemList.cshtml
@@ -1,42 +1,45 @@
 ﻿
 @model StockportWebapp.Models.GenericFeaturedItemList
 
-<div class="primary-topics">
-    @if (Model.HideButton == true)
-    {
-        <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
-            <partial name="GenericFeaturedItem" model='Model.Items' />
-        </div>
-    }
-    else
-    {
-        @for (var count = 0; count < 8; count += 4)
+    <div class="primary-topics">
+        @if (Model.HideButton)
         {
-            <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
-                <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)' />
+            @for (var count = 0; count < Model.Items.Count(); count += 4)
+            {
+                <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
+                    <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)' />
+                </div>
+             }
+        } 
+        else 
+        {
+            @for (var count = 0; count < 8; count += 4)
+            {
+                <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
+                    <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)' />
+                </div>
+            }
+        }
+    </div>
+
+    @if (!string.IsNullOrEmpty(Model.ButtonText))
+    {
+        <div class="generic-list-see-more-container">
+            @for (var count = 8; count < Model.Items.Count(); count += 4)
+            {
+                <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
+                    <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)' />
+                </div>
+            }
+        </div>
+        if (Model.Items.Count > 9)
+        {
+            <div>
+                <div class="featured-content-button-wrapper">
+                    <stock-button id="see-more-services" class="@Model.ButtonCssClass generic-list-see-more button-up-down">@Model.ButtonText</stock-button>
+                </div>
             </div>
         }
     }
-</div>
 
-@if (!string.IsNullOrEmpty(Model.ButtonText))
-{
-    <div class="generic-list-see-more-container">
-    @for (var count = 8; count < Model.Items.Count(); count += 4)
-    {
-            <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
-                <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)' />
-            </div>
-    }
-    </div>
-    if (Model.Items.Count > 9)
-    {
-        <div>
-            <div class="featured-content-button-wrapper">
-                <stock-button id="see-more-services" class="@Model.ButtonCssClass generic-list-see-more button-up-down">@Model.ButtonText</stock-button>
-            </div>
-        </div>
-    }
-}
-
-<script type="text/javascript" src="assets/javascript/stockportgov/EventFeatureItemFocus.js"></script>
+    <script type="text/javascript" src="assets/javascript/stockportgov/EventFeatureItemFocus.js"></script>

--- a/src/StockportWebapp/Views/stockportgov/Shared/GenericFeaturedItemList.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/GenericFeaturedItemList.cshtml
@@ -1,9 +1,6 @@
 ﻿
 @model StockportWebapp.Models.GenericFeaturedItemList
-@{
-    var take = string.IsNullOrEmpty(Model.ButtonText) ? Model.Items.Count : 8;
-    var noOfInitialTopics = 8;
-}
+
 <div class="primary-topics">
     @if (Model.HideButton == true)
     {
@@ -13,7 +10,7 @@
     }
     else
     {
-        @for (var count = 0; count < noOfInitialTopics; count += 4)
+        @for (var count = 0; count < 8; count += 4)
         {
             <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
                 <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)' />
@@ -24,14 +21,14 @@
 
 @if (!string.IsNullOrEmpty(Model.ButtonText))
 {
+    <div class="generic-list-see-more-container">
     @for (var count = 8; count < Model.Items.Count(); count += 4)
     {
-        <div class="generic-list-see-more-container">
             <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
                 <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)' />
             </div>
-        </div>
     }
+    </div>
     if (Model.Items.Count > 9)
     {
         <div>

--- a/src/StockportWebapp/Views/stockportgov/Shared/GenericFeaturedItemList.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/GenericFeaturedItemList.cshtml
@@ -5,45 +5,40 @@
     var noOfInitialTopics = 8;
 }
 <div class="primary-topics">
-    @for (var count = 0; count < noOfInitialTopics; count += 4)
-    {
-        <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
-            <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)' />
-        </div>
-    }
-
-</div>
-@if (!string.IsNullOrEmpty(Model.ButtonText))
-{
     @if (Model.HideButton == true)
     {
-        @foreach (var item in Model.Items)
-        {
-            <div class="generic-list-see-more-container">
-                <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
-                    <partial name="GenericFeaturedItem" model='item' />
-                </div>
-            </div>
-        }
+        <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
+            <partial name="GenericFeaturedItem" model='Model.Items' />
+        </div>
     }
     else
     {
-        @for (var count = 8; count < Model.Items.Count(); count += 4)
+        @for (var count = 0; count < noOfInitialTopics; count += 4)
         {
-            <div class="generic-list-see-more-container">
-                <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
-                    <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)' />
-                </div>
+            <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
+                <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)' />
             </div>
         }
-        if (Model.Items.Count > 9)
-        {
-            <div>
-                <div class="featured-content-button-wrapper">
-                    <stock-button id="see-more-services" class="@Model.ButtonCssClass generic-list-see-more button-up-down">@Model.ButtonText</stock-button>
-                </div>
+    }
+</div>
+
+@if (!string.IsNullOrEmpty(Model.ButtonText))
+{
+    @for (var count = 8; count < Model.Items.Count(); count += 4)
+    {
+        <div class="generic-list-see-more-container">
+            <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
+                <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)' />
             </div>
-        }
+        </div>
+    }
+    if (Model.Items.Count > 9)
+    {
+        <div>
+            <div class="featured-content-button-wrapper">
+                <stock-button id="see-more-services" class="@Model.ButtonCssClass generic-list-see-more button-up-down">@Model.ButtonText</stock-button>
+            </div>
+        </div>
     }
 }
 

--- a/src/StockportWebapp/Views/stockportgov/Shared/GenericFeaturedItemList.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/GenericFeaturedItemList.cshtml
@@ -1,45 +1,37 @@
 ﻿
 @model StockportWebapp.Models.GenericFeaturedItemList
 
-    <div class="primary-topics">
-        @if (Model.HideButton)
-        {
-            @for (var count = 0; count < Model.Items.Count(); count += 4)
-            {
-                <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
-                    <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)' />
-                </div>
-             }
-        } 
-        else 
-        {
-            @for (var count = 0; count < 8; count += 4)
-            {
-                <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
-                    <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)' />
-                </div>
-            }
-        }
-    </div>
+@{
+    var loopCount = Model.HideButton ? Model.Items.Count() : 8;
+}
 
-    @if (!string.IsNullOrEmpty(Model.ButtonText))
-    {
-        <div class="generic-list-see-more-container">
-            @for (var count = 8; count < Model.Items.Count(); count += 4)
-            {
-                <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
-                    <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)' />
-                </div>
-            }
-        </div>
-        if (Model.Items.Count > 9)
+<div class="primary-topics">
+        @for (var count = 0; count < loopCount; count += 4)
         {
-            <div>
-                <div class="featured-content-button-wrapper">
-                    <stock-button id="see-more-services" class="@Model.ButtonCssClass generic-list-see-more button-up-down">@Model.ButtonText</stock-button>
-                </div>
+            <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
+                <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)' />
             </div>
         }
-    }
+</div>
 
-    <script type="text/javascript" src="assets/javascript/stockportgov/EventFeatureItemFocus.js"></script>
+@if (!string.IsNullOrEmpty(Model.ButtonText))
+{
+    <div class="generic-list-see-more-container">
+        @for (var count = 8; count < Model.Items.Count(); count += 4)
+        {
+            <div class="featured-topic-list generic-Featured-Items-margin-top matchbox-parent">
+                <partial name="GenericFeaturedItem" model='Model.Items.Skip(count).Take(4)' />
+            </div>
+        }
+    </div>
+    if (Model.Items.Count > 9)
+    {
+        <div>
+            <div class="featured-content-button-wrapper">
+                <stock-button id="see-more-services" class="@Model.ButtonCssClass generic-list-see-more button-up-down">@Model.ButtonText</stock-button>
+            </div>
+        </div>
+    }
+}
+
+<script type="text/javascript" src="assets/javascript/stockportgov/EventFeatureItemFocus.js"></script>


### PR DESCRIPTION
### Description
-Remove 'View more categories' button from Events and Groups page.
-Display all categories for Events and Groups page.


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary