### PR TITLE
fix(TertiaryItems): add functionality to hide second column if only 1 item exists

### DIFF
--- a/src/StockportWebapp/Views/stockportgov/Shared/TertiaryItems.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/TertiaryItems.cshtml
@@ -10,8 +10,7 @@
 
     <div class="subitems-tertiary-two-column">
         <ul class="grid-50 mobile-grid-100 tablet-grid-100">
-            @foreach (var subItem in Model.TertiaryItems.Take(firstHalfOfItems))
-            {
+            @foreach (var subItem in Model.TertiaryItems.Take(firstHalfOfItems)) {
                 <li>
                     <div class="subitem-tertiary">
                         <a href="@subItem.NavigationLink">
@@ -22,26 +21,26 @@
             }
         </ul>
 
-        <ul class="grid-50 mobile-grid-100 tablet-grid-100">
-            @foreach (var subItem in Model.TertiaryItems.Skip(firstHalfOfItems))
-            {
-                <li>
-                    <div class="subitem-tertiary">
-                        <a href="@subItem.NavigationLink">
-                            @subItem.Title
-                        </a>
-                    </div>
-                </li>
-            }
-            @if (Model.TertiaryItems.Skip(firstHalfOfItems).Any() && (Model.TertiaryItems.Count() % 2 > 0))
-            {
-                <li>
-                    <div class="subitem-tertiary no-chevron">
+        @if (Model.TertiaryItems.Skip(firstHalfOfItems).Any()) {
+            <ul class="grid-50 mobile-grid-100 tablet-grid-100">
+                @foreach (var subItem in Model.TertiaryItems.Skip(firstHalfOfItems)) {
+                    <li>
+                        <div class="subitem-tertiary">
+                            <a href="@subItem.NavigationLink">
+                                @subItem.Title
+                            </a>
+                        </div>
+                    </li>
+                }
+                @if (Model.TertiaryItems.Count() % 2 > 0) {
+                    <li>
+                        <div class="subitem-tertiary no-chevron">
 
-                    </div>
-                </li>
-            }
-        </ul>
+                        </div>
+                    </li>
+                }
+            </ul>
+        }
         <div class="clearfix"></div>
     </div>
 </div>


### PR DESCRIPTION
Second ul no longer renders if only 1 tertiary item had been provided for topics.