### PR TITLE
fix(tab_order): add focus to 9th item when open

### DIFF
--- a/src/StockportWebapp/Views/stockportgov/Shared/GenericFeaturedItemList.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/GenericFeaturedItemList.cshtml
@@ -1,5 +1,4 @@
-﻿
-@model StockportWebapp.Models.GenericFeaturedItemList
+﻿@model StockportWebapp.Models.GenericFeaturedItemList
 
 @{
     var loopCount = Model.HideButton ? Model.Items.Count() : 8;
@@ -33,5 +32,3 @@
         </div>
     }
 }
-
-<script type="text/javascript" src="assets/javascript/stockportgov/EventFeatureItemFocus.js"></script>

--- a/src/StockportWebapp/wwwroot/assets/javascript/stockportgov/EventFeatureItemFocus.js
+++ b/src/StockportWebapp/wwwroot/assets/javascript/stockportgov/EventFeatureItemFocus.js
@@ -1,7 +1,0 @@
-﻿var topic = document.getElementsByClassName('featured-topic-link');
-
-window.onload = function () {
-    $("#see-more-services").click(function () {
-        topic[8].focus();
-    });
-};

--- a/src/StockportWebapp/wwwroot/assets/javascript/stockportgov/EventFeatureItemFocus.min.js
+++ b/src/StockportWebapp/wwwroot/assets/javascript/stockportgov/EventFeatureItemFocus.min.js
@@ -1,1 +1,0 @@
-var topic=document.getElementsByClassName("featured-topic-link");window.onload=function(){$("#see-more-services").click(function(){topic[8].focus()})};

--- a/src/StockportWebapp/wwwroot/assets/javascript/stockportgov/viewMoreSlider.js
+++ b/src/StockportWebapp/wwwroot/assets/javascript/stockportgov/viewMoreSlider.js
@@ -9,6 +9,9 @@
                 if (!$(self).hasClass("is-collapsed")) {
                     $(self).text($(self).text().replace('more', 'fewer'));
                     $(self).toggleClass("is-collapsed");
+                    if ($(".featured-topic-link")[8] !== undefined) {
+                        $(".featured-topic-link")[8].focus();
+                    }
                 }
                 else {
                     $(self).text($(self).text().replace('fewer', 'more'));


### PR DESCRIPTION
As per comments in [Jira D-6912](https://stockportbi.atlassian.net/browse/DIGITAL-6912), this fix confirms the focus is to be on the 9th item, which was previously hidden, and the focus-style ( orange border ) is to remain. Also fixes the issue of the current solution, as when you selected "View Less Services" it would try to attach the focus to a hidden element, and that broke in IE & Safari, taking the tab order back to the first item.

-) Removed EventFeatureItemFocus.js and minified version
-) Removed <script> call in GenericFeaturedItemList.cshtml to the above file
-) Added jQuery focus() on 9th featured item, if it is undefined, in viewMoreSlider.js, on the "expand call", ignores it on the "collapse call" within that function.

To test:

Pull the branch. Launch. Visit home page. In all browsers, specifically IE & Safari ( if anyone can afford a mac )...
Tab through to "view more" and hit enter. Should have focus on 9th item.
Tab down to "view less". If you tab over it, it goes to the next section, or if you hit enter, it should collapse that section but the focus will remain on the button, to continue tabbing down to the next section.
Try above with "clicking".
