### PR TITLE
feat(socialMediaLinks): add platform property for aria-label

### DIFF
--- a/src/StockportWebapp/ContentFactory/ShowcaseFactory.cs
+++ b/src/StockportWebapp/ContentFactory/ShowcaseFactory.cs
@@ -90,7 +90,8 @@ namespace StockportWebapp.ContentFactory
                 showcase.EventsReadMoreText,
                 video,
                 showcase.TypeformUrl,
-                showcase.SpotlightBanner
+                showcase.SpotlightBanner,
+                showcase.Platform
             );
         }
     }

--- a/src/StockportWebapp/Models/Showcase.cs
+++ b/src/StockportWebapp/Models/Showcase.cs
@@ -44,6 +44,8 @@ namespace StockportWebapp.Models
 
         public News NewsArticle { get; set; }
         public IEnumerable<Event> Events { get; set; }
+        public string Platform { get; set; }
+
 
         public Showcase()
         {

--- a/src/StockportWebapp/Models/SocialMediaLink.cs
+++ b/src/StockportWebapp/Models/SocialMediaLink.cs
@@ -6,13 +6,15 @@
         public string Slug { get; }
         public string Url { get; }
         public string Icon { get; }
+        public string Platform { get; }
 
-        public SocialMediaLink(string title, string slug, string url, string icon)
+        public SocialMediaLink(string title, string slug, string url, string icon, string platform)
         {
             Title = title;
             Slug = slug;
             Url = url;
             Icon = icon;
+            Platform = platform;
         }
     }
 
@@ -20,7 +22,7 @@
     {
         public NullSocialMediaLink()
             : base(
-                string.Empty, string.Empty, string.Empty, string.Empty)
+                string.Empty, string.Empty, string.Empty, string.Empty, string.Empty)
         { }
     }
 }

--- a/src/StockportWebapp/ProcessedModels/ProcessedShowcase.cs
+++ b/src/StockportWebapp/ProcessedModels/ProcessedShowcase.cs
@@ -44,6 +44,8 @@ namespace StockportWebapp.ProcessedModels
         public readonly Video Video;
         public readonly string TypeformUrl;
         public readonly SpotlightBanner SpotlightBanner;
+        public readonly string Platform;
+
 
         public ProcessedShowcase()
         { }
@@ -86,7 +88,8 @@ namespace StockportWebapp.ProcessedModels
             string eventsReadMoreText,
             Video video,
             string typeformUrl,
-            SpotlightBanner spotlightBanner)
+            SpotlightBanner spotlightBanner,
+            string platform)
         {
             Title = title;
             Slug = slug;
@@ -127,6 +130,7 @@ namespace StockportWebapp.ProcessedModels
             Video = video;
             TypeformUrl = typeformUrl;
             SpotlightBanner = spotlightBanner;
+            Platform = platform;
         }
     }
 }

--- a/src/StockportWebapp/Views/Shared/Components/SemanticFooterSocialMediaLinks/Default.cshtml
+++ b/src/StockportWebapp/Views/Shared/Components/SemanticFooterSocialMediaLinks/Default.cshtml
@@ -4,7 +4,7 @@
     @foreach (var socLink in Model.Item1)
     {
         <li>
-            <a aria-label="@socLink.Title" href="@socLink.Url">
+            <a aria-label="@socLink.Platform @socLink.Title" href="@socLink.Url">
                 <span class="fa @socLink.Icon"></span>
             </a>
         </li>

--- a/src/StockportWebapp/Views/Shared/SocialMediaLinks.cshtml
+++ b/src/StockportWebapp/Views/Shared/SocialMediaLinks.cshtml
@@ -18,7 +18,7 @@
         <a href="@socialMediaLink.Url">
             <span class="visuallyhidden">link to @nameOfSite @socialMediaLink.Title </span>
             <div class="icon-bordered icon-bordered-fixed icon-container icon-twitter @socialMediaCSS">
-                <span class="fa fab fa-2x @socialMediaLink.Icon" aria-hidden="true"></span>
+                <span class="fa fab fa-2x @socialMediaLink.Icon" aria-label="@socialMediaLink.Platform @socialMediaLink.Title"></span>
             </div>
         </a>
     }

--- a/src/StockportWebapp/Views/stockportgov/Shared/Semantic/Showcase/SocialMediaLinks.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/Semantic/Showcase/SocialMediaLinks.cshtml
@@ -3,12 +3,12 @@
 <section>
     <h2>@Model.SocialMediaLinksSubheading</h2>
     <div class="showcase-button-container">
-    @foreach (var link in Model.SocialMediaLinks)
-    {
-        <a as-link="true" class="showcase-button" href="@link.Url">
-                <span class="@link.Icon fa 2x" aria-label="@link.Title"></span>
-            <span aria-hidden="true">@link.Title</span>
-        </a>
-    }
+        @foreach (var link in Model.SocialMediaLinks)
+        {
+            <a as-link="true" class="showcase-button" href="@link.Url">
+                <span class="@link.Icon fa 2x" aria-label="@link.Platform @link.Title"></span>
+                <span aria-hidden="true">@link.Title</span>
+            </a>
+        }
     </div>
 </section>

--- a/src/StockportWebapp/Views/stockportgov/Shared/Semantic/Showcase/SocialMediaLinks.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/Semantic/Showcase/SocialMediaLinks.cshtml
@@ -6,8 +6,8 @@
     @foreach (var link in Model.SocialMediaLinks)
     {
         <a as-link="true" class="showcase-button" href="@link.Url">
-            <span class="@link.Icon fa 2x" aria-hidden="true"></span>
-            <span>@link.Title</span>
+                <span class="@link.Icon fa 2x" aria-label="@link.Title"></span>
+            <span aria-hidden="true">@link.Title</span>
         </a>
     }
     </div>


### PR DESCRIPTION
Platform property added to social links in the showcase and footer. This allows us to have 'Platform Title' in the aria label so the screen reader would read out 'Facebook @stockportMBC', whilst maintaining the Title text that's displayed on the page.