### PR TITLE
fix(server_headers): rm x-powered-by and server

### DIFF
--- a/src/StockportWebapp/web.config
+++ b/src/StockportWebapp/web.config
@@ -4,8 +4,16 @@
     <handlers>
       <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
     </handlers>
-    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="true" stdoutLogFile="C:\\Program Files\\Amazon\\ElasticBeanstalk\\logs\\webapplogs" forwardWindowsAuthToken="false">
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="true" stdoutLogFile="C:\\Program Files\\Amazon\\ElasticBeanstalk\\logs\\webapplogs" forwardWindowsAuthToken="false" hostingModel="inprocess">
       <environmentVariables />
     </aspNetCore>
+    <httpProtocol>
+      <customHeaders>
+        <remove name="X-Powered-By" />
+      </customHeaders>
+    </httpProtocol>
+	<security>
+		<requestFiltering removeServerHeader="true" />
+	</security>
   </system.webServer>
 </configuration>


### PR DESCRIPTION
Changed Web.Config to remove X-Powered-By & Server details from response to request

To test:
Pull the branch. Launch project. Developer Tools > Network > inspect localhost request and see that X-Powered-By and Server details are no longer in the response header

