### PR TITLE
News 'refined by' area render when page has no active filters (#6911)

### DIFF
--- a/src/StockportWebapp/Views/stockportgov/Shared/NewsListing.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/NewsListing.cshtml
@@ -7,7 +7,9 @@
 
 <div class="grid-container news-grid-container-margins">
     <div class="grid-30 tablet-grid-100 mobile-grid-100 l-filters" id="news-filters">
-        <h2 class="filters-heading">Refine by</h2>
+        @if (Model.HasActiveFilter()) {
+            <h2 class="filters-heading">Refine by</h2>
+        }
 
         <ul class="filters-list" id="displayRefineBy">
             @if (Model.HasActiveFilter()) {
@@ -28,7 +30,11 @@
             @if (Model.Categories.Any())
             {
                 <li class="filter collapsible" id="category-filter">
-                    <h3 tabindex="0"  class="filter-title focusable">Category</h3>
+                    @if (Model.HasActiveFilter()) {
+                        <h3 tabindex="0"  class="filter-title focusable">Category</h3>
+                    } else { 
+                        <h2 tabindex="0"  class="filter-title focusable">Category</h2>
+                    }
                     <ul class="filters-list">
                         <li class=@(Model.FilteredUrl.HasNoCategoryFilter() ? "active" : "")>
                             <a href="@Url.RouteUrl(Model.FilteredUrl.WithoutCategory())">All categories</a>
@@ -43,7 +49,11 @@
                 </li>
             }
             <li class="filter collapsible" id="news-archive">
-                <h3 tabindex="0" class="filter-title focusable">News archive</h3>
+                @if (Model.HasActiveFilter()) {
+                    <h3 tabindex="0" class="filter-title focusable">News archive</h3>
+                } else { 
+                    <h2 tabindex="0" class="filter-title focusable">News archive</h2>
+                }
                 <ul class="filters-list filters-outer-list" id="uitest-news-archive">
                     <li class=@(Model.FilteredUrl.HasNoDateFilter() ? "active" : "")>
                         <a href="@Url.RouteUrl(Model.FilteredUrl.WithoutDateFilter())">All recent news</a>


### PR DESCRIPTION
Following from previous [merge](https://github.com/smbc-digital/iag-webapp/commit/5e8607dde3d2cda95b4245c95b175327c61503b5), the 'refined by' heading no longer renders while no active filters exist on the page. 

In addition, the heading tags of both 'Category' and 'News Archive' get bumped to h2 when there are no active filters as to preserve the page heading structure.