### PR TITLE
fix(use_hsts): include subdomains & preload

### DIFF
--- a/src/StockportWebapp/Startup.cs
+++ b/src/StockportWebapp/Startup.cs
@@ -50,6 +50,8 @@ namespace StockportWebapp
 
             services.AddHsts(options =>
             {
+                options.Preload = true;
+                options.IncludeSubDomains = true;
                 options.MaxAge = TimeSpan.FromSeconds(31536000);
             });
 


### PR DESCRIPTION
I should have, but didn't realise that int and qa are both **subdomains** of smbcdigital.net, so I've set the includeSubdomains in the AddHsts() options.