### PR TITLE
fix(Zoom_Audit); revert to classic meta viewport

### DIFF
--- a/src/StockportWebapp/Views/Shared/Error.cshtml
+++ b/src/StockportWebapp/Views/Shared/Error.cshtml
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Error</title>
     <!--[if (gt IE 8) | (IEMobile)]><!-->
     <link rel="stylesheet" href="/assets/stylesheets/vendor/unsemantic-grid-responsive-tablet-min.css" />

--- a/src/StockportWebapp/Views/healthystockport/Shared/_LayoutError.cshtml
+++ b/src/StockportWebapp/Views/healthystockport/Shared/_LayoutError.cshtml
@@ -9,7 +9,7 @@
 <head>
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=12.0, minimum-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="shortcut icon" type="image/png" href="/assets/images/ui-images/Favicon.png" />
     <title>@ViewData["Title"]</title>
     <link href="//customer.cludo.com/css/112/1144/cludo-search-default.min.css" type="text/css" rel="stylesheet">

--- a/src/StockportWebapp/Views/healthystockport/Shared/_LayoutHome.cshtml
+++ b/src/StockportWebapp/Views/healthystockport/Shared/_LayoutHome.cshtml
@@ -8,7 +8,7 @@
 <head>
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=12.0, minimum-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="healthystockport.co.uk - helping people living or working in Stockport make positive lifestyle changes.">
     <link rel="shortcut icon" type="image/png" href="/assets/images/ui-images/Favicon.png" />
     <title>@ViewData["Title"]</title>

--- a/src/StockportWebapp/Views/stockportgov/Shared/_Layout.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/_Layout.cshtml
@@ -16,7 +16,7 @@
     @*<partial name="SecurityHeaders" />*@
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=12.0, minimum-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <partial name="OwnershipVerificationCodes" />
     <partial name="Favicon" />

--- a/src/StockportWebapp/Views/stockportgov/Shared/_LayoutError.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/_LayoutError.cshtml
@@ -11,7 +11,7 @@
     @* <partial name="SecurityHeaders" /> *@
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=12.0, minimum-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <partial name="OwnershipVerificationCodes" />
 

--- a/src/StockportWebapp/Views/stockportgov/Shared/_LayoutExternal.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/_LayoutExternal.cshtml
@@ -12,7 +12,7 @@
 <head>
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=12.0, minimum-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <partial name="Favicon" />
 
     <title>@ViewData["Title"] - Stockport Council</title>

--- a/src/StockportWebapp/Views/stockportgov/Shared/_LayoutHome.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/_LayoutHome.cshtml
@@ -9,7 +9,7 @@
     @* <partial name="SecurityHeaders" /> *@
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=12.0, minimum-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     @if (ViewData["Description"] != null)
     {
         <meta name="Description" content="@ViewData["Description"]" />

--- a/src/StockportWebapp/Views/stockportgov/Shared/_LayoutPrint.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/_LayoutPrint.cshtml
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=12.0, minimum-scale=1" />
+    <meta name="viewport" content="width=device-width" />
     <title>Stockport Council</title>
     <link href="~/assets/stylesheets/cludo-search-default.css" rel="stylesheet" />
     <link rel="stylesheet" href="/assets/stylesheets/vendor/unsemantic-grid-responsive-tablet-min.css" />

--- a/src/StockportWebapp/Views/stockportgov/Shared/_LayoutSemantic.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/_LayoutSemantic.cshtml
@@ -12,7 +12,7 @@
 <head>
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=12.0, minimum-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="shortcut icon" type="image/png" href="~/assets/images/ui-images/favicon-sg.png" />
     <title>@ViewData["Title"] - Stockport Council</title>
     @if (ViewData["Description"] != null)


### PR DESCRIPTION
A lot of documentation seems to point towards just sticking with the classic meta viewport settings... I looked back at the original commit for this back in 2017, which added the two other properties, but I don't know why they were added in the first place.