### PR TITLE
refactor(404cludo): update dynamic link to work on chromium browsers

### DIFF
--- a/src/StockportWebapp/Views/healthystockport/Error/Error.cshtml
+++ b/src/StockportWebapp/Views/healthystockport/Error/Error.cshtml
@@ -12,7 +12,7 @@
             <div class="page-description" itemprop="description">
                 <span class="error-page-icon" aria-hidden="true">i</span>
                 <h2 class="hero">Sorry, the page you were looking for has either moved or is no longer available.</h2>
-                <p id="homepage-link" class="invisible"><a href="/">Go back to the home page</a></p>
+                <p id="homepage-link" class="invisible"><a href="/">Go back to the homepage</a></p>
             </div>
 
             <!--[if lte IE 9]>

--- a/src/StockportWebapp/Views/stockportgov/Error/Error.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Error/Error.cshtml
@@ -9,7 +9,7 @@
             <div class="page-description" itemprop="description">
                 <span class="error-page-icon" aria-hidden="true">i</span>
                 <h2 class="hero">Sorry, the page you were looking for has either moved or is no longer available.</h2>
-                <p id="homepage-link" class="invisible"><a href="/">Go back to the home page</a></p>
+                <p id="homepage-link" class="invisible"><a href="/">Go back to the homepage</a></p>
             </div>
 
             <!--[if lte IE 9]>

--- a/src/StockportWebapp/wwwroot/assets/javascript/healthystockport/cludo.js
+++ b/src/StockportWebapp/wwwroot/assets/javascript/healthystockport/cludo.js
@@ -14,10 +14,22 @@
         CludoSearch = new Cludo(cludoSettings);
         CludoSearch.init();
 
-        $('#content').on('DOMSubtreeModified', function () {
-            if ($("#cludo-404").hasClass("loaded") && $("#cludo-404").hasClass("hide-module")) {
-                $("#homepage-link").removeClass("invisible");
+        const target = document.querySelector('#content');
+        const config = { attributes: true, childList: true, subtree: true };
+        const observerCallback = function (mutationsList, observer) {
+            const cludoModule = document.querySelector('#cludo-404');
+
+            for (const mutation of mutationsList) {
+                if (mutation.type === 'attributes' && cludoModule != null && cludoModule.classList.contains("loaded")) {
+                    observer.disconnect();
+
+                    if (cludoModule.classList.contains("hide-module"))
+                        document.querySelector("#homepage-link").classList.remove("invisible");
+                }
             }
-        });
+        }
+
+        const observer = new MutationObserver(observerCallback);
+        observer.observe(target, config);
     })();
 });

--- a/src/StockportWebapp/wwwroot/assets/javascript/stockportgov/cludo.js
+++ b/src/StockportWebapp/wwwroot/assets/javascript/stockportgov/cludo.js
@@ -17,11 +17,23 @@
     };
 
     var addHomepageLink = function () {
-        $('#content').on('DOMSubtreeModified', function () {
-            if ($("#cludo-404").hasClass("loaded") && $("#cludo-404").hasClass("hide-module")) {
-                $("#homepage-link").removeClass("invisible");
-            }
-        });
+        const target = document.querySelector('#content');
+        const config = { attributes: true, childList: true, subtree: true };
+        const observerCallback = function (mutationsList, observer) {
+            const cludoModule = document.querySelector('#cludo-404');
+
+            for (const mutation of mutationsList) {
+                if (mutation.type === 'attributes' && cludoModule != null && cludoModule.classList.contains("loaded")) {
+                    observer.disconnect();
+
+                    if (cludoModule.classList.contains("hide-module"))
+                        document.querySelector("#homepage-link").classList.remove("invisible");
+                }
+            }     
+        }
+
+        const observer = new MutationObserver(observerCallback);
+        observer.observe(target, config);
     }
 
     return {


### PR DESCRIPTION
## Dynamic Link Refactor
[Last PR](https://github.com/smbc-digital/iag-webapp/pull/135) a feature was added that used JQuery DOM update events to check if cludo had returned no results. Chromium browsers had dropped support for that a while ago, so this change swaps that functionality out for [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver), which has [full browser](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver#browser_compatibility) support. No functional changes have been made.

This PR also includes a small content change to the home page link text.