### PR TITLE
fix(video_tag_parser): rm logic for Topic

### DIFF
--- a/src/StockportWebapp/Controllers/TopicController.cs
+++ b/src/StockportWebapp/Controllers/TopicController.cs
@@ -3,9 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using StockportWebapp.Config;
 using StockportWebapp.Http;
 using StockportWebapp.Models;
-using StockportWebapp.Parsers;
 using StockportWebapp.Repositories;
-using StockportWebapp.Utils;
 using StockportWebapp.ViewModels;
 
 namespace StockportWebapp.Controllers
@@ -16,19 +14,12 @@ namespace StockportWebapp.Controllers
         private readonly IRepository _repository;
         private readonly IApplicationConfiguration _config;
         private readonly BusinessId _businessId;
-        private readonly ISimpleTagParserContainer _tagParserContainer;
-        private readonly MarkdownWrapper _markdownWrapper;
 
-        public TopicController(IRepository repository,
-                               IApplicationConfiguration config,
-                               BusinessId businessId, ISimpleTagParserContainer tagParserContainer,
-                               MarkdownWrapper markdownWrapper)
+        public TopicController(IRepository repository, IApplicationConfiguration config, BusinessId businessId)
         {
             _repository = repository;
             _config = config;
             _businessId = businessId;
-            _tagParserContainer = tagParserContainer;
-            _markdownWrapper = markdownWrapper;
         }
 
         [Route("/topic/{topicSlug}")]
@@ -38,13 +29,10 @@ namespace StockportWebapp.Controllers
 
             if (!topicHttpResponse.IsSuccessful())
                 return topicHttpResponse;
-
+            
             var topic = topicHttpResponse.Content as Topic;
 
             var urlSetting = _config.GetEmailAlertsNewSubscriberUrl(_businessId.ToString());
-
-            var body = _markdownWrapper.ConvertToHtml(topic.Body ?? "");
-            topic.Body = _tagParserContainer.ParseAll(body, topic.Title);
 
             return View(new TopicViewModel(topic, urlSetting.ToString()));
         }

--- a/src/StockportWebapp/Models/Topic.cs
+++ b/src/StockportWebapp/Models/Topic.cs
@@ -56,12 +56,11 @@ namespace StockportWebapp.Models
         public string PrimaryItemTitle { get; }
 
         public bool DisplayContactUs { get; set; }
-        public string Body { get; set; }
-
+        
         public Topic(string name, string slug, string summary, string teaser, string metaDescription, string icon,
             string backgroundImage, string image, IEnumerable<SubItem> subItems, IEnumerable<SubItem> secondaryItems, IEnumerable<SubItem> tertiaryItems, 
             IEnumerable<Crumb> breadcrumbs, IEnumerable<Alert> alerts, bool emailAlerts, string emailAlertsTopicId, EventBanner eventBanner, 
-            string expandingLinkTitle, IEnumerable<ExpandingLinkBox> expandingLinkBoxs, string primaryItemTitle, string title, bool displayContactUs, string body)
+            string expandingLinkTitle, IEnumerable<ExpandingLinkBox> expandingLinkBoxs, string primaryItemTitle, string title, bool displayContactUs)
         {
             Name = name;
             Title = title;
@@ -86,12 +85,11 @@ namespace StockportWebapp.Models
             ExpandingLinkBoxes = expandingLinkBoxs;
             PrimaryItemTitle = primaryItemTitle;
             DisplayContactUs = displayContactUs;
-            Body = body;
         }
     }
 
     public class NullTopic : Topic
     {
-        public NullTopic() : base(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new List<SubItem>(), new List<SubItem>(), new List<SubItem>(), new List<Crumb>(), new List<Alert>(), false, string.Empty, null, string.Empty, new List<ExpandingLinkBox>(), string.Empty, string.Empty, true, string.Empty) { }
+        public NullTopic() : base(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new List<SubItem>(), new List<SubItem>(), new List<SubItem>(), new List<Crumb>(), new List<Alert>(), false, string.Empty, null, string.Empty, new List<ExpandingLinkBox>(), string.Empty, string.Empty, true) { }
     }
 }

--- a/src/StockportWebapp/Views/healthystockport/Topic/Index.cshtml
+++ b/src/StockportWebapp/Views/healthystockport/Topic/Index.cshtml
@@ -40,7 +40,6 @@
             <h1>@topic.Name</h1>
             <hr>
             @Html.Raw(topic.Summary)
-            @Html.Raw(topic.Body)
         </div>
         
         <partial name="SubItem-List" model='topic'/>        

--- a/test/StockportWebappTests/Unit/Controllers/TopicControllerTest.cs
+++ b/test/StockportWebappTests/Unit/Controllers/TopicControllerTest.cs
@@ -9,9 +9,7 @@ using StockportWebapp.Config;
 using StockportWebapp.Controllers;
 using StockportWebapp.Http;
 using StockportWebapp.Models;
-using StockportWebapp.Parsers;
 using StockportWebapp.Repositories;
-using StockportWebapp.Utils;
 using StockportWebapp.ViewModels;
 using Xunit;
 
@@ -23,8 +21,6 @@ namespace StockportWebappTests_Unit.Unit.Controllers
         private readonly Mock<IRepository> _repository;
         private const string BusinessId = "businessId";
         private readonly EventBanner _eventBanner;
-        private readonly Mock<ISimpleTagParserContainer> _tagParserContainer;
-        private readonly Mock<MarkdownWrapper> _markdownWrapper;
 
         public TopicControllerTest()
         {
@@ -32,17 +28,8 @@ namespace StockportWebappTests_Unit.Unit.Controllers
 
             config.Setup(o => o.GetEmailAlertsNewSubscriberUrl(BusinessId)).Returns(AppSetting.GetAppSetting("email-alerts-url"));
 
-            _tagParserContainer = new Mock<ISimpleTagParserContainer>();
-
-            _markdownWrapper = new Mock<MarkdownWrapper>();
-
             _repository = new Mock<IRepository>();
-            _controller = new TopicController(_repository.Object,
-                                              config.Object,
-                                              new BusinessId(BusinessId),
-                                              _tagParserContainer.Object,
-                                              _markdownWrapper.Object
-                                              );
+            _controller = new TopicController(_repository.Object, config.Object, new BusinessId(BusinessId));
             _eventBanner = new EventBanner("title", "teaser", "icon", "link");
         }
         
@@ -58,7 +45,7 @@ namespace StockportWebappTests_Unit.Unit.Controllers
 
             var topic = new Topic("Name", "slug", "Summary", "Teaser", "metaDescription", "Icon", "Image", "Image", subItems, null, null,
                 new List<Crumb>(), new List<Alert>(), true, "test-id", _eventBanner, "expandingLinkText",
-                new List<ExpandingLinkBox>{ new ExpandingLinkBox("title", subItems) }, string.Empty, string.Empty, true, string.Empty);
+                new List<ExpandingLinkBox>{ new ExpandingLinkBox("title", subItems) }, string.Empty, string.Empty, true);
 
             const string slug = "healthy-living";
             _repository.Setup(o => o.Get<Topic>(slug, null)).ReturnsAsync(new HttpResponse(200, topic, string.Empty));
@@ -93,8 +80,7 @@ namespace StockportWebappTests_Unit.Unit.Controllers
             var subItems = Enumerable.Range(0, 1).Select(CreateASubItem).ToList();
 
             var topic = new Topic("Name", "slug", "Summary", "Teaser", "metaDescription", "Icon", "Image", "Image", subItems, null, null,
-              new List<Crumb>(), new List<Alert>(), true, "test-id", _eventBanner, "expandingLinkText", new List<ExpandingLinkBox>(),
-              string.Empty, string.Empty, true, string.Empty);
+              new List<Crumb>(), new List<Alert>(), true, "test-id", _eventBanner, "expandingLinkText", new List<ExpandingLinkBox>(), string.Empty, string.Empty, true);
 
             const string slug = "healthy-living";
             _repository.Setup(o => o.Get<Topic>(slug, null)).ReturnsAsync(new HttpResponse(200, topic, string.Empty));
@@ -135,8 +121,7 @@ namespace StockportWebappTests_Unit.Unit.Controllers
             };
 
             var topic = new Topic("Name", "slug", "Summary", "Teaser", "metaDescription", "Icon", "Image", "Image", null, null, null,
-               new List<Crumb>(), alerts, true, "test-id", _eventBanner, "expandingLinkText", new List<ExpandingLinkBox>(), string.Empty,
-               string.Empty, true, string.Empty);
+               new List<Crumb>(), alerts, true, "test-id", _eventBanner, "expandingLinkText", new List<ExpandingLinkBox>(), string.Empty, string.Empty, true);
 
             const string slug = "healthy-living";
             _repository.Setup(o => o.Get<Topic>(slug, null)).ReturnsAsync(new HttpResponse(200, topic, string.Empty));

--- a/test/StockportWebappTests/Unit/ViewModels/ArticleViewModelTest.cs
+++ b/test/StockportWebappTests/Unit/ViewModels/ArticleViewModelTest.cs
@@ -186,11 +186,7 @@ namespace StockportWebappTests_Unit.Unit.ViewModels
             var firstSecondaryitem = new SubItem(TextHelper.AnyString, "first-secondaryitem", TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, new List<SubItem>());
             var secondaryItems = new List<SubItem> { firstSecondaryitem };
 
-            var topic = new Topic(TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString,
-                TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, subItems, secondaryItems,new List<SubItem>(), new List<Crumb>(),
-                new List<Alert>(), false, TextHelper.AnyString, null, String.Empty, new List<ExpandingLinkBox>(), String.Empty, string.Empty,
-                true, string.Empty);
-
+            var topic = new Topic(TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, subItems, secondaryItems,new List<SubItem>(), new List<Crumb>(), new List<Alert>(), false, TextHelper.AnyString, null, String.Empty, new List<ExpandingLinkBox>(), String.Empty, string.Empty, true);
             var article = new ProcessedArticle(TextHelper.AnyString,TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, new List<ProcessedSection>(),
                 TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, new List<Crumb>(), new List<Alert>(), topic, new List<Alert>(), null, new DateTime(), new bool());
 
@@ -220,11 +216,8 @@ namespace StockportWebappTests_Unit.Unit.ViewModels
             var subItems = new List<SubItem> { firstSubItem, secondSubItem, thirdSubItem, fourthSubItem };
             var secondaryItems = new List<SubItem> { fifthSubItem, sixthSubItem, seventhSubItem, eightSubItem };
 
-            var topic = new Topic(TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString,
-                TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, subItems, secondaryItems, new List<SubItem>(), new List<Crumb>(),
-                new List<Alert>(), false, TextHelper.AnyString, null, "expandingLinkText", new List<ExpandingLinkBox>(), string.Empty,
-                string.Empty, true, string.Empty);
-            
+            var topic = new Topic(TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString,
+                subItems, secondaryItems, new List<SubItem>(), new List<Crumb>(), new List<Alert>(), false, TextHelper.AnyString, null, "expandingLinkText", new List<ExpandingLinkBox>(), string.Empty, string.Empty, true);
             var article = new ProcessedArticle(TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, new List<ProcessedSection>(), TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, new List<Crumb>(), new List<Alert>(), topic, new List<Alert>(), null, new DateTime(), new bool());
 
             var articleViewModel = new ArticleViewModel(article);
@@ -290,8 +283,7 @@ namespace StockportWebappTests_Unit.Unit.ViewModels
         {
 
             var parentTopic = new Topic("Name", "slug", "Summary", "Teaser", "metaDescription", "Icon", "Image", "Image", null, null, null,
-                new List<Crumb>(), null, true, "test-id", null, "expandingLinkText", new List<ExpandingLinkBox>(), string.Empty, string.Empty,
-                true, string.Empty);
+                new List<Crumb>(), null, true, "test-id", null, "expandingLinkText", new List<ExpandingLinkBox>(), string.Empty, string.Empty, true);
 
             return new ProcessedArticle(TextHelper.AnyString, slug, TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, sections,
                 TextHelper.AnyString, TextHelper.AnyString, TextHelper.AnyString, new List<Crumb>(), new List<Alert>(), parentTopic, new List<Alert>(), null, new DateTime(), new bool());

--- a/test/StockportWebappTests/Unit/ViewModels/TopicViewModelTest.cs
+++ b/test/StockportWebappTests/Unit/ViewModels/TopicViewModelTest.cs
@@ -16,9 +16,8 @@ namespace StockportWebappTests_Unit.Unit.ViewModels
             const bool emailAlerts = true;
             const string emailAlertsTopicId = "topic-id";
 
-            var topic = new Topic("name", "slug", "metaDescription", "summary", "teaser", "icon", "backgroundimage", "image", new List<SubItem>(),
-                new List<SubItem>(), new List<SubItem>(), new List<Crumb>(), new List<Alert>(), emailAlerts, emailAlertsTopicId, null,
-                "expandingLinkText", new List<ExpandingLinkBox>(), string.Empty, string.Empty, true, string.Empty);
+            var topic = new Topic("name", "slug", "metaDescription", "summary", "teaser", "icon", "backgroundimage", "image", new List<SubItem>(), new List<SubItem>(), new List<SubItem>(),
+                new List<Crumb>(), new List<Alert>(), emailAlerts, emailAlertsTopicId, null, "expandingLinkText", new List<ExpandingLinkBox>(), string.Empty, string.Empty, true);
 
             var topicViewModel = new TopicViewModel(topic, EmailAlertsUrl);
 
@@ -32,8 +31,9 @@ namespace StockportWebappTests_Unit.Unit.ViewModels
             const string emailAlertsTopicId = "";
 
             var topic = new Topic("name", "slug", "metaDescription", "summary", "teaser", "icon", "backgroundimage", "image",
-                new List<SubItem>(), new List<SubItem>(), new List<SubItem>(), new List<Crumb>(), new List<Alert>(), emailAlerts,
-                emailAlertsTopicId, null, "expandingLinkText", new List<ExpandingLinkBox>(), string.Empty, string.Empty, true, string.Empty);
+                new List<SubItem>(), new List<SubItem>(), new List<SubItem>(),
+                new List<Crumb>(), new List<Alert>(), emailAlerts, emailAlertsTopicId, null, "expandingLinkText",
+                new List<ExpandingLinkBox>(), string.Empty, string.Empty, true);
 
             var topicViewModel = new TopicViewModel(topic, EmailAlertsUrl);
 


### PR DESCRIPTION
Removed logic which added functionality where it was originally mentioned on the card, but after investigation was not actually required at the moment. Confirmed with Jon H & Laura. Issue [Jira #8152](https://stockportbi.atlassian.net/browse/DIGITAL-8152).

To test:
Pull branch and launch.
Check localhost/healthy-stockport-article and you should see a video
Check localhost/topic/uitest-healthy-weight and you should not see a video