### PR TITLE
Feature/list first subscription

### DIFF
--- a/src/StockportWebapp/Controllers/HomeController.cs
+++ b/src/StockportWebapp/Controllers/HomeController.cs
@@ -50,13 +50,24 @@ namespace StockportWebapp.Controllers
         }
 
         [Route("/subscribe")]
-        public async Task<IActionResult> EmailSubscribe(string emailAddress, [FromQuery] string EmailAlertsTopicId)
+        public async Task<IActionResult> EmailSubscribe(string emailAddress, string emailAlertsTopicId)
         {
-            var urlSetting = _config.GetEmailAlertsUrl(_businessId.ToString());
-            if (!urlSetting.IsValid()) 
-                return NotFound();
+            AppSetting urlSetting = null;
+            string redirectUrl = null;
 
-            var redirectUrl = string.Concat(urlSetting, emailAddress) + "&topic_id=" + EmailAlertsTopicId;
+            if (!string.IsNullOrEmpty(emailAddress))
+            {
+                urlSetting = _config.GetEmailAlertsUrl(_businessId.ToString());
+                redirectUrl = string.Concat(urlSetting, $"?email={emailAddress}");
+            }
+            else if (!string.IsNullOrEmpty(emailAlertsTopicId))
+            {
+                urlSetting = _config.GetEmailAlertsNewSubscriberUrl(_businessId.ToString());
+                redirectUrl += string.Concat(urlSetting, $"?topic_id={emailAlertsTopicId}");
+            }
+
+            if (urlSetting is null || !urlSetting.IsValid())
+                return NotFound();
 
             return await Task.FromResult(Redirect(redirectUrl));
         }

--- a/src/StockportWebapp/Controllers/NewsController.cs
+++ b/src/StockportWebapp/Controllers/NewsController.cs
@@ -75,7 +75,7 @@ namespace StockportWebapp.Controllers
             DoPagination(newsRoom, model, page ,pageSize);
           
             model.AddNews(newsRoom);
-            model.AddUrlSetting(urlSetting);
+            model.AddUrlSetting(urlSetting, model.Newsroom.EmailAlertsTopicId);
 
             return View(model);
         }

--- a/src/StockportWebapp/ViewModels/NewsroomViewModel.cs
+++ b/src/StockportWebapp/ViewModels/NewsroomViewModel.cs
@@ -56,9 +56,11 @@ namespace StockportWebapp.ViewModels
             Newsroom = newsRoom;
         }
 
-        internal void AddUrlSetting(AppSetting urlSetting)
+        internal void AddUrlSetting(AppSetting urlSetting, string topicId)
         {
-            EmailAlertsUrl = urlSetting.ToString();
+            EmailAlertsUrl = !string.IsNullOrEmpty(topicId) ?
+                string.Concat(urlSetting.ToString(), "?topic_id=", topicId) :
+                urlSetting.ToString();
         }
 
         public string GetActiveDateFilter()

--- a/src/StockportWebapp/Views/stockportgov/Comms/Index.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Comms/Index.cshtml
@@ -70,9 +70,6 @@
         </div>
     </article>
     <aside class="article-aside">
-        @{
-            ViewData["SignUpAlertsTopicIdTopicId"] = Model.Homepage.EmailAlertsTopicId;
-        }
         <partial name="../Shared/SignUpAlerts.cshtml" />
 
         @if (Model.Homepage.UsefulLinks.Any())

--- a/src/StockportWebapp/Views/stockportgov/News/Index.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/News/Index.cshtml
@@ -29,8 +29,7 @@
             <div class="header-right-button grid-30 tablet-grid-30 mobile-grid-100">
                 @if (Model.Newsroom.EmailAlerts)
                 {
-
-                    <stock-button as-link="true" class="button-outline-white-transparent" href="@Model.EmailAlertsUrl" target="_blank"><span class="fa fa-envelope-o fa-1x" aria-hidden="true"></span>Email alerts</stock-button>
+                    <stock-button as-link="true" class="button-outline-white-transparent" href="@Model.EmailAlertsUrl"><span class="fa fa-envelope-o fa-1x" aria-hidden="true"></span>Email alerts</stock-button>
                 }
                 else
                 {

--- a/src/StockportWebapp/Views/stockportgov/Shared/Header.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/Header.cshtml
@@ -39,7 +39,7 @@
                                     <div class="menu-links">
                                         <a href="https://myaccount.stockport.gov.uk/">My Account</a>
                                         <a href="https://myaccount.stockport.gov.uk/account/settings">Account settings</a>
-                                        <a class="typeform-share link" data-mode="1" target="_blank" href="https://public.govdelivery.com/accounts/UKSMBC/subscriber/new">Email alerts</a>
+                                        <a class="typeform-share link" data-mode="1" target="_blank" href="https://int-formbuilder-origin.smbcdigital.net/list-subscription/signup">Email alerts</a>
                                         <a class="sign-out" href="https://myaccount.stockport.gov.uk/account/logout">Sign out</a>
                                     </div>
                                 </div>
@@ -60,7 +60,7 @@
                                                 <ul>
                                                     <li><a href="https://myaccount.stockport.gov.uk/">My Account</a></li>
                                                     <li><a href="https://myaccount.stockport.gov.uk/account/settings">Account settings</a></li>
-                                                    <li><a class="typeform-share link" data-mode="1" target="_blank" href="https://public.govdelivery.com/accounts/UKSMBC/subscriber/new">Email alerts</a></li>
+                                                    <li><a class="typeform-share link" data-mode="1" target="_blank" href="https://int-formbuilder-origin.smbcdigital.net/list-subscription/signup">Email alerts</a></li>
                                                     <li><a class="sign-out" href="https://myaccount.stockport.gov.uk/account/logout">Sign out</a></li>
                                                 </ul>
                                             </nav>

--- a/src/StockportWebapp/Views/stockportgov/Shared/Header.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/Header.cshtml
@@ -39,7 +39,6 @@
                                     <div class="menu-links">
                                         <a href="https://myaccount.stockport.gov.uk/">My Account</a>
                                         <a href="https://myaccount.stockport.gov.uk/account/settings">Account settings</a>
-                                        <a class="typeform-share link" data-mode="1" target="_blank" href="https://int-formbuilder-origin.smbcdigital.net/list-subscription/signup">Email alerts</a>
                                         <a class="sign-out" href="https://myaccount.stockport.gov.uk/account/logout">Sign out</a>
                                     </div>
                                 </div>
@@ -60,7 +59,6 @@
                                                 <ul>
                                                     <li><a href="https://myaccount.stockport.gov.uk/">My Account</a></li>
                                                     <li><a href="https://myaccount.stockport.gov.uk/account/settings">Account settings</a></li>
-                                                    <li><a class="typeform-share link" data-mode="1" target="_blank" href="https://int-formbuilder-origin.smbcdigital.net/list-subscription/signup">Email alerts</a></li>
                                                     <li><a class="sign-out" href="https://myaccount.stockport.gov.uk/account/logout">Sign out</a></li>
                                                 </ul>
                                             </nav>

--- a/src/StockportWebapp/Views/stockportgov/Shared/HeaderExternal.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/HeaderExternal.cshtml
@@ -39,7 +39,7 @@
                                     <div class="menu-links">
                                         <a href="https://myaccount.stockport.gov.uk/">My Account</a>
                                         <a href="https://myaccount.stockport.gov.uk/account/settings">Account settings</a>
-                                        <a class="typeform-share link" data-mode="1" target="_blank" href="https://public.govdelivery.com/accounts/UKSMBC/subscriber/new">Email alerts</a>
+                                        <a class="typeform-share link" data-mode="1" target="_blank" href="https://int-formbuilder-origin.smbcdigital.net/list-subscription/signup">Email alerts</a>
                                         <a class="sign-out" href="https://myaccount.stockport.gov.uk/account/logout">Sign out</a>
                                     </div>
                                 </div>
@@ -60,7 +60,7 @@
                                                 <ul>
                                                     <li><a href="https://myaccount.stockport.gov.uk/">My Account</a></li>
                                                     <li><a href="https://myaccount.stockport.gov.uk/account/settings">Account settings</a></li>
-                                                    <li><a class="typeform-share link" data-mode="1" target="_blank" href="https://public.govdelivery.com/accounts/UKSMBC/subscriber/new">Email alerts</a></li>
+                                                    <li><a class="typeform-share link" data-mode="1" target="_blank" href="https://int-formbuilder-origin.smbcdigital.net/list-subscription/signup">Email alerts</a></li>
                                                     <li><a class="sign-out" href="https://myaccount.stockport.gov.uk/account/logout">Sign out</a></li>
                                                 </ul>
                                             </nav>

--- a/src/StockportWebapp/Views/stockportgov/Shared/HeaderExternal.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/HeaderExternal.cshtml
@@ -39,7 +39,6 @@
                                     <div class="menu-links">
                                         <a href="https://myaccount.stockport.gov.uk/">My Account</a>
                                         <a href="https://myaccount.stockport.gov.uk/account/settings">Account settings</a>
-                                        <a class="typeform-share link" data-mode="1" target="_blank" href="https://int-formbuilder-origin.smbcdigital.net/list-subscription/signup">Email alerts</a>
                                         <a class="sign-out" href="https://myaccount.stockport.gov.uk/account/logout">Sign out</a>
                                     </div>
                                 </div>
@@ -60,7 +59,6 @@
                                                 <ul>
                                                     <li><a href="https://myaccount.stockport.gov.uk/">My Account</a></li>
                                                     <li><a href="https://myaccount.stockport.gov.uk/account/settings">Account settings</a></li>
-                                                    <li><a class="typeform-share link" data-mode="1" target="_blank" href="https://int-formbuilder-origin.smbcdigital.net/list-subscription/signup">Email alerts</a></li>
                                                     <li><a class="sign-out" href="https://myaccount.stockport.gov.uk/account/logout">Sign out</a></li>
                                                 </ul>
                                             </nav>

--- a/src/StockportWebapp/Views/stockportgov/Shared/Semantic/EmailBanner.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/Semantic/EmailBanner.cshtml
@@ -7,8 +7,7 @@
     </div>
     <div>
         <h2 class="h3">@Model.EmailAlertsText</h2>
-        <form method="get" role="form" action="/subscribe">
-            <input type="email" name="emailAddress" placeholder="Enter your email address" title="Enter your email address" aria-label="Enter your email address">
+        <form method="post" role="form" action="/subscribe">
             <button type="submit" id="test-subscribe" class="button-primary">Subscribe</button>
             @Html.HiddenFor(o => o.EmailAlertsTopicId)
         </form>

--- a/src/StockportWebapp/Views/stockportgov/Shared/SemanticHeader.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/SemanticHeader.cshtml
@@ -27,7 +27,7 @@
                     <span class="fa fa-caret-up" aria-hidden="true"></span>
                     @Html.ActionLink("My Account", "Index", "Dashboard")
                     @Html.ActionLink("Account settings", "Settings", "Account")
-                    <a class="typeform-share link" data-mode="1" target="_blank" href="https://public.govdelivery.com/accounts/UKSMBC/subscriber/new">Email alerts</a>
+                    <a class="typeform-share link" data-mode="1" target="_blank" href="https://int-formbuilder-origin.smbcdigital.net/list-subscription/signup">Email alerts</a>
                     @Html.ActionLink("Sign out", "Logout", "Account", null, new { @class = "sign-out" })
                 </nav>
             </div>
@@ -47,7 +47,7 @@
                             <li>@Html.ActionLink("My Account", "Index", "Dashboard")</li>
                             <li>@Html.ActionLink("Account settings", "Settings", "Account")</li>
                             <li>
-                                <a class="typeform-share link" data-mode="1" target="_blank" href="https://public.govdelivery.com/accounts/UKSMBC/subscriber/new">Email alerts</a>
+                                <a class="typeform-share link" data-mode="1" target="_blank" href="https://int-formbuilder-origin.smbcdigital.net/list-subscription/signup">Email alerts</a>
                             </li>
                             <li>@Html.ActionLink("Sign out", "Logout", "Account", null, new { @class = "sign-out" })</li>
                         </ul>

--- a/src/StockportWebapp/Views/stockportgov/Shared/SemanticHeader.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/SemanticHeader.cshtml
@@ -27,7 +27,6 @@
                     <span class="fa fa-caret-up" aria-hidden="true"></span>
                     @Html.ActionLink("My Account", "Index", "Dashboard")
                     @Html.ActionLink("Account settings", "Settings", "Account")
-                    <a class="typeform-share link" data-mode="1" target="_blank" href="https://int-formbuilder-origin.smbcdigital.net/list-subscription/signup">Email alerts</a>
                     @Html.ActionLink("Sign out", "Logout", "Account", null, new { @class = "sign-out" })
                 </nav>
             </div>
@@ -46,9 +45,6 @@
                         <ul>
                             <li>@Html.ActionLink("My Account", "Index", "Dashboard")</li>
                             <li>@Html.ActionLink("Account settings", "Settings", "Account")</li>
-                            <li>
-                                <a class="typeform-share link" data-mode="1" target="_blank" href="https://int-formbuilder-origin.smbcdigital.net/list-subscription/signup">Email alerts</a>
-                            </li>
                             <li>@Html.ActionLink("Sign out", "Logout", "Account", null, new { @class = "sign-out" })</li>
                         </ul>
                     </nav>

--- a/src/StockportWebapp/Views/stockportgov/Shared/SignUpAlerts.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/SignUpAlerts.cshtml
@@ -1,5 +1,5 @@
 ﻿<section class="sign-up-alert">
-    <form action="/subscribe?EmailAlertsTopicId=@ViewData["SignUpAlertsTopicIdTopicId"]" method="POST">
+    <form action="/subscribe" method="POST">
         <label for="emailAddress">Sign up to receive our news and email alerts in your inbox</label>
         <input type="email" name="emailAddress" id="emailAddress" placeholder="Enter your email address">
         <button class="button-primary-white" type="submit">Subscribe</button>

--- a/src/StockportWebapp/Views/stockportgov/Topic/Index.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Topic/Index.cshtml
@@ -27,7 +27,7 @@
             @if (Model.Topic.EmailAlerts)
             {
                 <div class="header-right-button grid-30 tablet-grid-30 mobile-grid-100">
-                    <stock-button as-link="true" class="button-outline-white-transparent" href="@Model.EmailAlertsUrl" target="_blank"><span class="fa fa-envelope-o fa-1x" aria-hidden="true"></span>Email alerts</stock-button>
+                    <stock-button as-link="true" class="button-outline-white-transparent" href="@Model.EmailAlertsUrl"><span class="fa fa-envelope-o fa-1x" aria-hidden="true"></span>Email alerts</stock-button>
                 </div>
             }
         </div>

--- a/src/StockportWebapp/app-config/appsettings.json
+++ b/src/StockportWebapp/app-config/appsettings.json
@@ -29,8 +29,8 @@
     },
     "Search": "http://stockport.searchimprove.com/search.aspx?pc=&pckid=816028173&aid=448530&pt=6018936&addid=&sw=",
     "Postcode": "http://maps.stockport.gov.uk/myhouse.aspx?atTxtStreet=",
-    "EmailAlerts": "https://int-formbuilder-origin.smbcdigital.net/email-subscription/signup?email=",
-    "EmailAlertsNewSubscriber": "https://public.govdelivery.com/accounts/UKSMBC/subscriber/new",
+    "EmailAlerts": "https://int-formbuilder-origin.smbcdigital.net/email-subscription/signup",
+    "EmailAlertsNewSubscriber": "https://localhost:44331/list-subscription/signup",
     "DigitalStockportLink": "http://digitalstockport.info",
     "RssEmail": "info@stockport.gov.uk",
     "Email": {

--- a/src/StockportWebapp/app-config/appsettings.json
+++ b/src/StockportWebapp/app-config/appsettings.json
@@ -29,8 +29,8 @@
     },
     "Search": "http://stockport.searchimprove.com/search.aspx?pc=&pckid=816028173&aid=448530&pt=6018936&addid=&sw=",
     "Postcode": "http://maps.stockport.gov.uk/myhouse.aspx?atTxtStreet=",
-    "EmailAlerts": "https://int-formbuilder-origin.smbcdigital.net/email-subscription/signup",
-    "EmailAlertsNewSubscriber": "https://localhost:44331/list-subscription/signup",
+    "EmailAlerts": "https://int-formbuilder-origin.smbcdigital.net/email-subscription/",
+    "EmailAlertsNewSubscriber": "https://int-formbuilder-origin.smbcdigital.net/list-subscription/",
     "DigitalStockportLink": "http://digitalstockport.info",
     "RssEmail": "info@stockport.gov.uk",
     "Email": {

--- a/src/StockportWebapp/app-config/appsettings.prod.json
+++ b/src/StockportWebapp/app-config/appsettings.prod.json
@@ -39,8 +39,8 @@
       }
     ]
   },
-  "EmailAlerts": "https://prod-formbuilder-origin.smbcdigital.net/email-subscription/signup?email=",
-  "EmailAlertsNewSubscriber": "https://prod-formbuilder-origin.smbcdigital.net/list-subscription/",
+  "EmailAlerts": "https://forms.stockport.gov.uk/email-subscription/signup?email=",
+  "EmailAlertsNewSubscriber": "https://forms.stockport.gov.uk/list-subscription/",
   "GroupArchiveEmailPeriods": [
     {
       "numOfDays": 90,

--- a/src/StockportWebapp/app-config/appsettings.prod.json
+++ b/src/StockportWebapp/app-config/appsettings.prod.json
@@ -40,6 +40,7 @@
     ]
   },
   "EmailAlerts": "https://prod-formbuilder-origin.smbcdigital.net/email-subscription/signup?email=",
+  "EmailAlertsNewSubscriber": "https://prod-formbuilder-origin.smbcdigital.net/list-subscription/",
   "GroupArchiveEmailPeriods": [
     {
       "numOfDays": 90,

--- a/src/StockportWebapp/app-config/appsettings.qa.json
+++ b/src/StockportWebapp/app-config/appsettings.qa.json
@@ -32,5 +32,6 @@
     ]
   },
   "EmailAlerts": "https://qa-formbuilder-origin.smbcdigital.net/email-subscription/signup?email=",
+  "EmailAlertsNewSubscriber": "https://qa-formbuilder-origin.smbcdigital.net/list-subscription/",
   "HttpClientConfiguration:0:gatewayType": "StockportGovUK.NetStandard.Gateways.Civica.Pay.CivicaPayTestGateway, StockportGovUk.NetStandard.Gateways"
 }

--- a/src/StockportWebapp/app-config/appsettings.stage.json
+++ b/src/StockportWebapp/app-config/appsettings.stage.json
@@ -33,6 +33,7 @@
     ]
   },
   "EmailAlerts": "https://stage-formbuilder-origin.smbcdigital.net/email-subscription/signup?email=",
+  "EmailAlertsNewSubscriber": "https://stage-formbuilder-origin.smbcdigital.net/list-subscription/",
   "GroupArchiveEmailPeriods": [
     {
       "numOfDays": 90,

--- a/test/StockportWebappTests_UI/StepDefinitions/NewsSteps.cs
+++ b/test/StockportWebappTests_UI/StepDefinitions/NewsSteps.cs
@@ -71,7 +71,7 @@
                     result = BrowserSession.FindCss("#category-filter ul").Exists();
                     break;
                 case "Email alerts":
-                    result = BrowserSession.FindCss("a[href*='https://public.govdelivery.com/accounts/UKSMBC/subscriber/new']").Exists();
+                    result = BrowserSession.FindCss("a[href*='https://int-formbuilder-origin.smbcdigital.net/list-subscription/signup']").Exists();
                     break;
                 case "news articles":
                     result = BrowserSession.FindCss(".nav-card-news-list").Exists() && BrowserSession.FindAllCss(".nav-card-news-list li").Any();


### PR DESCRIPTION

Changed Home Controller > Subscribe to actually now only allow one kind of redirect, based on the WiredPlus implementations that only cover Email First, or List First, subscriptions.
Also removed the [FromQuery] attribute as that was only used once, and unnecessary - removed that params which were part of a post request anyway.

Changed NewsController to append the list Id if given to the appsettings url, which it wasn't doing previously, so couldn't see how it'd been working before. Works now though.

Changed links to not open in a new tab for this journey.

Removed Granicus ( broken links to public.govdelivery.com/accounts/UKSMBC/subscriber/new ) from 3 headers, which also weren't used... removed these from DTS also, even though the functionality to "manage" your subscriptions will go back into my account.

Updated appsettings for the right environments to point to the right version of the form in formbuilder.