### PR TITLE
feat(100): try to push one "fix" for our accessibility score

### DIFF
--- a/src/StockportWebapp/Views/Shared/Components/Footer/Default.cshtml
+++ b/src/StockportWebapp/Views/Shared/Components/Footer/Default.cshtml
@@ -5,7 +5,7 @@
 @inject IApplicationConfiguration appConfig
 @inject BusinessId BusinessId
 <script>(function () { var qs, js, q, s, d = document, gi = d.getElementById, ce = d.createElement, gt = d.getElementsByTagName, id = 'typef_orm', b = 'https://s3-eu-west-1.amazonaws.com/share.typeform.com/'; if (!gi.call(d, id)) { js = ce.call(d, 'script'); js.id = id; js.src = b + 'share.js'; q = gt.call(d, 'script')[0]; q.parentNode.insertBefore(js, q) } })()</script>
-<footer>
+<footer aria-hidden="false">
     @if (BusinessId.ToString() == "stockportgov")
     {
         <partial name="AToZStockportGov" model='""' />


### PR DESCRIPTION
Oddity that in our codebase we do not set aria-hidden="true" on any footer element... but it gets set in production environment... so, I suggest we explicitly set this to false to enforce the point and ideally get our accessibility score up to 100. I ran the idea past Laura & Jon who seem happy to go for it and give it a try.