### PR TITLE
fix(HS_TOPIC_NAVIGATION): display if ALL have img

### DIFF
--- a/src/StockportWebapp/Views/healthystockport/Shared/SubItem-List.cshtml
+++ b/src/StockportWebapp/Views/healthystockport/Shared/SubItem-List.cshtml
@@ -1,12 +1,13 @@
-﻿@model StockportWebapp.Models.SubItem
+﻿@model Tuple<StockportWebapp.Models.SubItem, bool>
 @{
-    var item = Model;
+    var item = Model.Item1;
+    var displayImage = Model.Item2;
     var imageUrl = item.Image;
 }
 
 <li class="article-list-item article-list-item-mobile grid-33 tablet-grid-50 mobile-grid-50 matchbox-item">
     <a href="@item.NavigationLink" class="article-list-item-block grid-45 tablet-grid-45">
-        @if (!string.IsNullOrEmpty(imageUrl))
+        @if (displayImage)
         {
             <div style="margin: 0 -10px 0 -10px;">
                 <img style="width: 100%;"

--- a/src/StockportWebapp/Views/healthystockport/Topic/Index.cshtml
+++ b/src/StockportWebapp/Views/healthystockport/Topic/Index.cshtml
@@ -61,9 +61,10 @@ else if (!string.IsNullOrEmpty(topic.BackgroundImage))
         <ul class="article-list article-list-container grid-100 matchbox-parent">
             @if (topic.SubItems.Any())
             {
+                bool displayImages = topic.SubItems.All(item => !string.IsNullOrEmpty(item.Image));
                 foreach (var item in topic.SubItems)
                 {
-                    <partial name="SubItem-List" model="item" />
+                    <partial name="SubItem-List" model="new Tuple<SubItem, bool>(item, displayImages)" />
                 }
             }
         </ul>


### PR DESCRIPTION
During sign off - it was requested that the Subitems ( Primary Items in Contentful ) would only display images if ALL Primary items had an image to display.

A lock, of sorts, to stop having a potentially different navigation items and funky layout.

This is a similar action to how Stockport Gov works with it's Topic.