### PR TITLE
feat(CallToAction): + property to processed model

### DIFF
--- a/src/StockportWebapp/ContentFactory/TopicFactory.cs
+++ b/src/StockportWebapp/ContentFactory/TopicFactory.cs
@@ -25,7 +25,10 @@ namespace StockportWebapp.ContentFactory
             return new ProcessedTopic(topic.Name, topic.Slug, summary, topic.Teaser, topic.MetaDescription, topic.Icon, topic.BackgroundImage,
                 topic.Image, topic.SubItems, topic.SecondaryItems, topic.TertiaryItems, topic.Breadcrumbs, topic.Alerts, topic.EmailAlerts,
                 topic.EmailAlertsTopicId, topic.EventBanner, topic.ExpandingLinkTitle, topic.ExpandingLinkBoxes, topic.PrimaryItemTitle,
-                topic.Title,topic.DisplayContactUs, topic.CampaignBanner, topic.EventCategory);
+                topic.Title, topic.DisplayContactUs, topic.CampaignBanner, topic.EventCategory)
+            {
+                CallToAction = topic.CallToAction
+            };
         }
     }
 }


### PR DESCRIPTION
Add CallToAction in new ProcessedTopic model in new Factory.

I need to run a refactor card for Healthy Stockport > Topic as now the Events API call can go within the factory too. But, I may need to add this in to the constructor to ensure it's not left out. Although I don't "like" that massive constructor on the model, I can't see right now what way would be better. It previously didn't need to be in the constructor when it was simply model bound as is.