### PR TITLE
Fix/accessibility

### DIFF
--- a/src/StockportWebapp/Views/healthystockport/Shared/BrowserCheck.cshtml
+++ b/src/StockportWebapp/Views/healthystockport/Shared/BrowserCheck.cshtml
@@ -1,4 +1,4 @@
-﻿<noscript role="contentinfo" aria-label="Javascript disabled information">
+﻿<noscript>
     <div class="banner-header-container banner-header-warning-unsupported" role="alert" aria-label="noscript">
         <div class="grid-container grid-100">
             <div class="banner-header grid-100 mobile-grid-100 tablet-grid-100">

--- a/src/StockportWebapp/Views/healthystockport/Topic/Index.cshtml
+++ b/src/StockportWebapp/Views/healthystockport/Topic/Index.cshtml
@@ -41,11 +41,11 @@ else if (!string.IsNullOrEmpty(topic.BackgroundImage))
     <div class="grid-100 l-background-hs-image"></div>
 }
 
-<div aria-label="@Model.Topic.Name content" class="grid-100 mobile-grid-100 topic-container">
+<article id="content" class="grid-100 mobile-grid-100 topic-container">
     <div class="grid-100 topic-container-holder">
         @if (topic.Alerts is not null)
         {
-            <div tabindex="-1" id="content" class="topic-container-holder-alert">
+            <div class="topic-container-holder-alert">
                 @foreach (var alert in topic.Alerts)
                 {
                     <partial name="DisplayTemplates/Alert" model='alert' />
@@ -121,4 +121,4 @@ else if (!string.IsNullOrEmpty(topic.BackgroundImage))
         }
 
     </div>
-</div>
+</article>

--- a/src/StockportWebapp/Views/stockportgov/Shared/BrowserCheck.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/BrowserCheck.cshtml
@@ -1,4 +1,4 @@
-﻿<noscript role="contentinfo" aria-label="Javascript disabled information">
+﻿<noscript>
     <div class="banner-header-container banner-header-warning-unsupported">
         <div class="grid-container grid-100">
             <div class="banner-header grid-100 mobile-grid-100 tablet-grid-100">

--- a/src/StockportWebapp/Views/stockportgov/Shared/BrowserCheckSemantic.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/BrowserCheckSemantic.cshtml
@@ -1,4 +1,4 @@
-﻿<noscript role="contentinfo" aria-label="Javascript disabled information">
+﻿<noscript>
     <div class="banner-header javascript-error">
         <div class="center-wrapper">
             <span>JavaScript off</span>To get the best experience on this website please use a browser with JavaScript enabled.


### PR DESCRIPTION
Mostly to fix the Topic view... the "skip to main content" currently passes by the main article because it doesn't have the id="content", so the screen reader reads out "blank". Removed the Aria Label as this uses a semantic element with readable content within.

Also to remove the role and aria label for the noscript tag... this comes up as an issue in the accessibility AXE tools, and the [documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript) says the noscript element is not permitted to have a role.