### PR TITLE
fix(ViewMoreSlider): change .includes to .search

### DIFF
--- a/src/StockportWebapp/wwwroot/assets/javascript/stockportgov/viewMoreSlider.js
+++ b/src/StockportWebapp/wwwroot/assets/javascript/stockportgov/viewMoreSlider.js
@@ -8,13 +8,14 @@
                 container.slideToggle(200, function () {
                     container.toggleClass("is-collapsed");
                     var oldButtonText = button.text();
-                    if (oldButtonText.includes("fewer")) {
-                        button.text(oldButtonText.replace('fewer', 'more'));
-                        $('html, body').animate({ scrollTop: (button.offset().top - 250) + 'px' });
-                    }
-                    else {
+                    var index = oldButtonText.search("fewer"); // -1 means no start index found
+                    if (index === -1) {
                         button.text(oldButtonText.replace('more', 'fewer'));
                         container.find(".featured-topic-link:first").focus();
+                    }
+                    else {
+                        button.text(oldButtonText.replace('fewer', 'more'));
+                        $('html, body').animate({ scrollTop: (button.offset().top - 250) + 'px' });
                     }
                     button.toggleClass("is-collapsed");
                 });


### PR DESCRIPTION
I pushed a bug into IE for the initial quick fix of the view more slider interrupting the Recite Me script which was blocking the use of the WebApp Accessibility tool.

The Accessibility tool works in IE now, but the View More Slider does not work as expected, as IE does not support the JavaScript function I used ( .includes ).  So, needed to switch the logic to include IE browser support, and use the ".search" string api, which returns the starting index of the substring found match in the string. If no match is found it returns a "-1".