### PR TITLE
chore(events): change time to 12 hour from 24 hour

### DIFF
--- a/src/StockportWebapp/Views/stockportgov/Events/Detail.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Events/Detail.cshtml
@@ -61,7 +61,7 @@
                                         <div class="events-details-heading">
                                             <h3>Date and time</h3>
                                         </div>
-                                        @Model.EventDate.ToString("dddd dd MMMM yyyy") @Model.StartTime - @Model.EndTime
+                                        @Model.EventDate.ToString("dddd dd MMMM yyyy") @DateTime.Parse(Model.StartTime).ToString("h:mm tt") - @DateTime.Parse(Model.EndTime).ToString("h:mm tt")
                                     </div>
                                     <div class="clearfix"></div>
                                 </li>


### PR DESCRIPTION
"The way we display the time of event is inconsistent - change the display of the time on an event so that it is in 12 hours am/pm format on the events page" - [jira card](https://stockportbi.atlassian.net/browse/DIGITAL-8732) circa 2022