### PR TITLE
chore(events): make datetime format match homepage style

### DIFF
--- a/src/StockportWebapp/Views/stockportgov/Events/Detail.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Events/Detail.cshtml
@@ -61,7 +61,7 @@
                                         <div class="events-details-heading">
                                             <h3>Date and time</h3>
                                         </div>
-                                        @Model.EventDate.ToString("dddd dd MMMM yyyy") @DateTime.Parse(Model.StartTime).ToString("h:mm tt") - @DateTime.Parse(Model.EndTime).ToString("h:mm tt")
+                                        @Model.EventDate.ToString("dddd dd MMMM yyyy") @DateTime.Parse(Model.StartTime).ToString("h:mmtt").ToLower() - @DateTime.Parse(Model.EndTime).ToString("h:mmtt").ToLower()
                                     </div>
                                     <div class="clearfix"></div>
                                 </li>


### PR DESCRIPTION
The way i had the time formatted (10:00 AM) didn't match with the way it's shown before you click on the event (10:00am), so this is a change to fix that.