### PR TITLE
fix(Events): specific view returned

### DIFF
--- a/src/StockportWebapp/Controllers/EventsController.cs
+++ b/src/StockportWebapp/Controllers/EventsController.cs
@@ -238,7 +238,7 @@ namespace StockportWebapp.Controllers
                 ViewBag.Eventdate = eventItem?.EventDate.ToString("yyyy-MM-dd");
             }
 
-            return View(eventItem);
+            return View("Detail", eventItem);
         }
 
         [Route("/events/add-your-event")]


### PR DESCRIPTION
revert the controller action that needs the view specified ( as it was before I changed it ) because the implied view does not exist.