### PR TITLE
fix(General): rm Bouncy Castle

### DIFF
--- a/src/StockportWebapp/Views/stockportgov/Groups/ManageGroup.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Groups/ManageGroup.cshtml
@@ -1,5 +1,4 @@
-﻿@using Org.BouncyCastle.Math.Field
-@using StockportWebapp.Config
+﻿@using StockportWebapp.Config
 @using StockportWebapp.Models
 @using StockportWebapp.ViewModels
 @model ManageGroupViewModel
@@ -29,8 +28,7 @@
                                     </div>
                                 </div>
                                 @if (Model.IsArchived)
-                                { 
-
+                                {
                                     <a id="view-group" href="@Url.Action(Model.Slug, "groups")">
                                         <div class="grid-100 sk-table-row grid-parent">
                                             <div class="sk-table-cell">


### PR DESCRIPTION
Bouncy Castle ( large package ) being pulled in to the project, not from NuGet, but from a @using statement in one view, ManageGroup.cshtml, which uses the main layout and has no partial views. Risk is low, and it's only managing a group, which has been broken before, but can't see what aspect of "Field" would have been used anyway. Checked the Git history and even the commit that brought this in had no reasoning behind it. Not that it's fool proof... so we can soon see what a fool I may be.