### PR TITLE
fix(Events): "add-to-calendar" url return type

### DIFF
--- a/src/StockportWebapp/Controllers/EventsController.cs
+++ b/src/StockportWebapp/Controllers/EventsController.cs
@@ -247,8 +247,13 @@ public class EventsController : Controller
     }
 
     [Route("events/add-to-calendar")]
-    public IActionResult AddToCalendar(string type, string eventUrl, string slug, DateTime eventDate, string name, string location, string startTime, string endTime, string description, string summary)
+    public IActionResult AddToCalendar(string type, string eventUrl,
+        string slug, DateTime eventDate, string name, string location,
+        string startTime, string endTime, string description, string summary)
     {
+        if (string.IsNullOrEmpty(type))
+            return NotFound();
+
         var eventItem = new Event()
         {
             Slug = slug,
@@ -262,17 +267,11 @@ public class EventsController : Controller
         };
 
         if (type.Equals("google") || type.Equals("yahoo"))
-        {
-            var url = _helper.GetCalendarUrl(eventItem, eventUrl, type);
-            return Redirect(url);
-        }
+            return Redirect(_helper.GetCalendarUrl(eventItem, eventUrl, type));
 
         if (type.Equals("windows") || type.Equals("apple"))
-        {
-            byte[] calendarBytes = Encoding.UTF8.GetBytes(_helper.GetIcsText(eventItem, eventUrl));
-            return File(calendarBytes, "text/calendar", slug + ".ics");
-        }
+            return File(Encoding.UTF8.GetBytes(_helper.GetIcsText(eventItem, eventUrl)), "text/calendar", slug + ".ics");
 
-        return null;
+        return Ok();
     }
 }

--- a/src/StockportWebapp/Views/Shared/ShareViaCalendar.cshtml
+++ b/src/StockportWebapp/Views/Shared/ShareViaCalendar.cshtml
@@ -7,17 +7,26 @@
     <p>Add to calendar</p>
     <div class="addthis_toolbox">
         <div class="custom_images">
-            <a href="@Url.Action("AddToCalendar", "Events", new {type = "windows", eventUrl = @url, slug = Model.Slug, eventDate = ViewBag.Eventdate, name = Model.Title, location = Model.Location, startTime = Model.StartTime, endTime = Model.EndTime, summary = Model.Teaser})"
-                aria-label="Add to Outlook Calendar"><span class="fa fa-windows" aria-hidden="true"></span></a>
+
+            <a href="@Url.Action("AddToCalendar", "Events", new { type = "windows", eventUrl = @url, slug = Model.Slug, eventDate = ViewBag.Eventdate, name = Model.Title, location = Model.Location, startTime = Model.StartTime, endTime = Model.EndTime, summary = Model.Teaser})"
+                aria-label="Add to Outlook Calendar">
+                <span class="fa fa-windows" aria-hidden="true"></span>
+            </a>
+
             <a href="@Url.Action("AddToCalendar", "Events", new {type = "google", eventUrl = @url, slug = Model.Slug, eventDate = ViewBag.Eventdate, name = Model.Title, location = Model.Location, startTime = Model.StartTime, endTime = Model.EndTime, summary = Model.Teaser})"
-                target="_blank" aria-label="Add to Google  Calendar"><span class="fa fa-google"
-                    aria-hidden="true"></span></a>
+                target="_blank" aria-label="Add to Google  Calendar">
+                <span class="fa fa-google" aria-hidden="true"></span>
+            </a>
+
             <a href="@Url.Action("AddToCalendar", "Events", new {type = "apple", eventUrl = @url, slug = Model.Slug, eventDate = ViewBag.Eventdate, name = Model.Title, location = Model.Location, startTime = Model.StartTime, endTime = Model.EndTime, summary = Model.Teaser})"
-                aria-label="Add to Apple Calendar"><span class="fa fa-apple" aria-hidden="true"></span></a>
-            <a class="hide-on-mobile hide-on-tablet"
-                href="@Url.Action("AddToCalendar", "Events", new {type = "yahoo", eventUrl =@url, slug = Model.Slug, eventDate = ViewBag.Eventdate, name = Model.Title, location = Model.Location, startTime = Model.StartTime, endTime = Model.EndTime, summary = Model.Teaser})"
-                target="_blank" aria-label="Add to Yahoo  Calendar"><span class="fa fa-yahoo"
-                    aria-hidden="true"></span></a>
+                aria-label="Add to Apple Calendar">
+                <span class="fa fa-apple" aria-hidden="true"></span>
+            </a>
+
+            <a class="hide-on-mobile hide-on-tablet" href="@Url.Action("AddToCalendar", "Events", new {type = "yahoo", eventUrl =@url, slug = Model.Slug, eventDate = ViewBag.Eventdate, name = Model.Title, location = Model.Location, startTime = Model.StartTime, endTime = Model.EndTime, summary = Model.Teaser})"
+                target="_blank" aria-label="Add to Yahoo Calendar">
+                <span class="fa fa-yahoo" aria-hidden="true"></span>
+            </a>
         </div>
     </div>
 </div>

--- a/src/StockportWebapp/wwwroot/robots-healthystockport-live.txt
+++ b/src/StockportWebapp/wwwroot/robots-healthystockport-live.txt
@@ -3,6 +3,7 @@ Disallow:
 Crawl-delay: 120
 Disallow: /contact
 Disallow: /search
+Disallow: /events/add-to-calendar/
 Disallow: /*.jpg$
 Disallow: /*.jpeg$
 Disallow: /*.png$

--- a/src/StockportWebapp/wwwroot/robots-stockportgov-live.txt
+++ b/src/StockportWebapp/wwwroot/robots-stockportgov-live.txt
@@ -8,6 +8,7 @@ Disallow: /*.bmp$
 Disallow: /*.pdf$
 Disallow: /*.svg$
 Disallow: /*_hidden
+Disallow: /events/add-to-calendar/
 
 User-agent: SemrushBot
 User-agent: BLEXBot


### PR DESCRIPTION
IAction Result cannot return null

the url https://www.stockport.gov.uk/events/add-to-calendar returns a 500 error because of it.

add the url to robots.txt file so it’s not indexed / crawlable

return Ok, not null… and NotFound if no “type” in the request