### PR TITLE
tests(navcard): amend cypress test

### DIFF
--- a/test/UIAndBrowserTests/cypress/e2e/BrowserTests/Homepage/nav-card-functionality.cy.js
+++ b/test/UIAndBrowserTests/cypress/e2e/BrowserTests/Homepage/nav-card-functionality.cy.js
@@ -8,7 +8,6 @@ describe("Navcard functionality", () => {
         cy.viewport(size);
       }
       cy.visit("")
-      //Content for the Navcards is content managed, only testing the componant is clickable. We can't control errors caused by CMS.
       cy.get('[data-cy="nav-card-link"]')
       .should("have.length", 9)
       .first()

--- a/test/UIAndBrowserTests/cypress/e2e/BrowserTests/Homepage/nav-card-functionality.cy.js
+++ b/test/UIAndBrowserTests/cypress/e2e/BrowserTests/Homepage/nav-card-functionality.cy.js
@@ -1,16 +1,19 @@
 describe("Navcard functionality", () => {
   const viewports = ["iphone-x", [1440, 900]];
   viewports.map((size) => {
-    it(`tests on ${size} screen to check the Navcards are clickable and go to a new page location`, () => {
+    it(`tests on ${size} screen to check a Navcard can be clicked and loads new page`, () => {
       if (Cypress._.isArray(size)) {
         cy.viewport(size[0], size[1]);
       } else {
         cy.viewport(size);
       }
       cy.visit("")
+      //Content for the Navcards is content managed, only testing the componant is clickable. We can't control errors caused by CMS.
       cy.get('[data-cy="nav-card-link"]')
       .should("have.length", 9)
-      .click({ multiple: true });
+      .first()
+      .click()
+      cy.url().should('not.eq','https://qa-iag-stockportgov.smbcdigital.net/')
     });
   });
 });


### PR DESCRIPTION
I have written a test that checks the number of Navcards and then clicks on the first one to make sure it goes to a new location. The content in the Navcards is content managed so not sure if this test is all that useful and might get removed as we keep adding tests. 