### PR TITLE
refactor(Webapp): added data cy to global alert html

### DIFF
--- a/src/StockportWebapp/Views/stockportgov/Shared/GlobalAlert.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/GlobalAlert.cshtml
@@ -7,7 +7,7 @@
 
 @if (!isDismissed)
 {
-    <div class="global-alert-@Model.Severity.ToLowerInvariant()">
+    <div class="global-alert-@Model.Severity.ToLowerInvariant() data-cy="global-alert-wrapper" >
         <div class="grid-container grid-100 global-alert-container">
             <div class="grid-100 mobile-grid-100 tablet-grid-100 global-alert grid-parent">
                 <div class="hide-on-mobile hide-on-tablet global-alert-icon global-alert-icon-@Model.Severity.ToLowerInvariant()" data-cy="alert-icon">

--- a/src/StockportWebapp/Views/stockportgov/Shared/GlobalAlert.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/GlobalAlert.cshtml
@@ -7,7 +7,7 @@
 
 @if (!isDismissed)
 {
-    <div class="global-alert-@Model.Severity.ToLowerInvariant() data-cy="global-alert-wrapper" >
+    <div class="global-alert-@Model.Severity.ToLowerInvariant()" data-cy ="global-alert-wrapper">
         <div class="grid-container grid-100 global-alert-container">
             <div class="grid-100 mobile-grid-100 tablet-grid-100 global-alert grid-parent">
                 <div class="hide-on-mobile hide-on-tablet global-alert-icon global-alert-icon-@Model.Severity.ToLowerInvariant()" data-cy="alert-icon">


### PR DESCRIPTION
Added data-cy="global-alert-wrapper" to the GlobalAlert.cstml. Not sure this is the right place but need to try it, the UI snapshot tests and structure tests for alerts are failing due to the data-cy="global-alert-wrapper" no longer being there. Not sure when it was removed but the tests have worked previously. 