### PR TITLE
fix(directory-entry): only show filters section if highlight bool true

### DIFF
--- a/src/StockportWebapp/Views/stockportgov/Directory/DirectoryEntry.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Directory/DirectoryEntry.cshtml
@@ -156,7 +156,7 @@
                         </div>
                     </div>
 
-                    @if (highlightedFilters is not null)
+                    @if (highlightedFilters.Any())
                     {
                         <div class="directory__filters">
                             <div class="directory__wrapper">


### PR DESCRIPTION
- Change to content api means the filters list can no longer be null, only empty.
- Swap null check to .Any to handle this.