### PR TITLE
chore(directory-entry): image tag for nu html error

### DIFF
--- a/src/StockportWebapp/Views/stockportgov/Directory/DirectoryEntry.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Directory/DirectoryEntry.cshtml
@@ -46,8 +46,7 @@
                 <div class="directory--30 directory--border-top">
                     <div class="directory__wrapper">
                         @if(!string.IsNullOrEmpty(directory.Image)){
-                            <img src="@directory.Image?w=350&q=89"
-                                srcset="@directory.Image?w=350&q=89&fm=webp"
+                            <img src="@directory.Image?w=350&q=89&fm=webp"
                                 class="directory__logo"
                                 alt=""
                                 width="350"

--- a/src/StockportWebapp/Views/stockportgov/Directory/DirectoryEntry.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Directory/DirectoryEntry.cshtml
@@ -47,7 +47,7 @@
                     <div class="directory__wrapper">
                         @if(!string.IsNullOrEmpty(directory.Image)){
                             <img src="@directory.Image?w=350&q=89"
-                                srcset="@directory.Image?w=350&q=89&fm=webp 350w"
+                                srcset="@directory.Image?w=350&q=89&fm=webp"
                                 class="directory__logo"
                                 alt=""
                                 width="350"


### PR DESCRIPTION
- Nu html checker was showing an error when an img contains a srcset attribute without a sizes attribute. The Mozilla docs provide examples that only contatin a srcset attribute so I'm not sure how required it is.
- Not able to use the nu html checker to test locally so have just removed the size from the end of the srcset tag to see if that makes a difference for now.