### PR TITLE
chore(navcardList): remove current item for subItems

### DIFF
--- a/src/StockportWebapp/Views/stockportgov/Shared/ArticleNavCardList.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/ArticleNavCardList.cshtml
@@ -4,7 +4,8 @@
     string liClasses = "navcard navcard--grey navcard--no-margin navcard--no-padding-right-rtl navcard--width-100";
     string paddingBottom = $"navcard--border-bottom-1 navcard--radius-bottom-left navcard--radius-bottom-right";
     bool hasMoreButton;
-    var sidebarSubItems = Model.SidebarSubItems(out hasMoreButton);
+    var sidebarSubItems = Model.SidebarSubItems(out hasMoreButton)
+                            .Where(subItem => !subItem.NavigationLink.Equals(Model.Article.NavigationLink));
 }
 
 <nav aria-labelledby="navcard__title">
@@ -19,18 +20,15 @@
 
         @foreach (var item in sidebarSubItems)
         {
-            if (!item.NavigationLink.Equals(Model.Article.NavigationLink))
-            {
-                bool isLastItem = item.Equals(sidebarSubItems.Last()) && !hasMoreButton;
-                <li class="@liClasses">
-                    <div class="@borderGrey @(isLastItem ? paddingBottom : null)">
-                        <partial name="ArticleNavCard" model="item"
-                                 view-data='isLastItem
+            bool isLastItem = item.Equals(sidebarSubItems.Last()) && !hasMoreButton;
+            <li class="@liClasses">
+                <div class="@borderGrey @(isLastItem ? paddingBottom : null)">
+                    <partial name="ArticleNavCard" model="item"
+                             view-data='isLastItem
                                     ? new ViewDataDictionary(ViewData) {{ "navcardPadding", " navcard--padding-bottom" }}
                                     : null' />
-                    </div>
-                </li>
-            }
+                </div>
+            </li>
         }
 
         @if (hasMoreButton)

--- a/src/StockportWebapp/Views/stockportgov/Shared/ArticleNavCardList.cshtml
+++ b/src/StockportWebapp/Views/stockportgov/Shared/ArticleNavCardList.cshtml
@@ -4,7 +4,7 @@
     string liClasses = "navcard navcard--grey navcard--no-margin navcard--no-padding-right-rtl navcard--width-100";
     string paddingBottom = $"navcard--border-bottom-1 navcard--radius-bottom-left navcard--radius-bottom-right";
     bool hasMoreButton;
-    var sidebarSubItems = Model.SidebarSubItems(out hasMoreButton)
+    IEnumerable<SubItem> sidebarSubItems = Model.SidebarSubItems(out hasMoreButton)
                             .Where(subItem => !subItem.NavigationLink.Equals(Model.Article.NavigationLink));
 }
 


### PR DESCRIPTION
If an article was the last item the padding bottom wasn't displaying properly.
![image](https://github.com/user-attachments/assets/a464d680-c425-4de5-8ec1-62faf82b65c2)
The sidebarItems now only contains items that aren't the current item, so item.Last() should now work as intended.
![image](https://github.com/user-attachments/assets/0e3854a0-b624-4db4-87b9-5a05ad88cbc7)

